### PR TITLE
[PORT] Play internet sound - Custom track titles

### DIFF
--- a/code/modules/admin/verbs/playsound.dm
+++ b/code/modules/admin/verbs/playsound.dm
@@ -106,10 +106,7 @@ GLOBAL_VAR_INIT(web_sound_cooldown, 0)
 		if (duration > 10 MINUTES)
 			if((tgui_alert(user, "This song is over 10 minutes long. Are you sure you want to play it?", "Length Warning", list("No", "Yes", "Cancel")) != "Yes"))
 				return
-		// IRIS EDIT - ORIGINAL: 		var/include_song_data = tgui_alert(user, "Show the title of and link to this song to the players?\n[title]", "Song Info", list("Yes", "No", "Cancel"))
-		// switch(include_song_data)
-		//IRIS EDIT CHANGE - Allow custom title input
-		var/include_song_data = tgui_input_list(user, "Show the title of and link to this song to the players?\n[title]", "Show Info?", list("Yes", "No", "Custom Title", "Cancel"))
+		var/include_song_data = tgui_input_list(user, "Show the title of and link to this song to the players?\n[title]", "Show Info?", list("Yes", "No", "Custom Title", "Cancel")) // IRIS EDIT, ORIGINAL: var/include_song_data = tgui_alert(user, "Show the title of and link to this song to the players?\n[title]", "Song Info", list("Yes", "No", "Cancel"))
 		switch(include_song_data)
 			if("Yes")
 				music_extra_data["title"] = data["title"]


### PR DESCRIPTION
## About The Pull Request
- Ports https://github.com/Monkestation/Monkestation2.0/pull/3622 
## Why it's Good for the Game

admeme foolery! also some URLs played via ytdlp can return nothing at times.

## Proof of Testing

<img width="715" height="93" alt="image" src="https://github.com/user-attachments/assets/4459fc5d-a163-4a99-a62d-3dbc5337571d" />


https://github.com/user-attachments/assets/708a35bc-1f84-4874-849e-bc7e5a50802c



## Changelog
:cl:
admin: "Play Internet Sound" now has a "Custom Title" option
/:cl:
