### PR TITLE
Fix eye emissives being misaligned for different heights

### DIFF
--- a/code/modules/surgery/bodyparts/head.dm
+++ b/code/modules/surgery/bodyparts/head.dm
@@ -220,6 +220,13 @@
 				worn_face_offset.apply_offset(emissive_right)
 				worn_face_offset.apply_offset(emissive_left)
 
+			// OCULIS EDIT ADDITION START - fix issue with heights
+			if(ishuman(update_on))
+				var/mob/living/carbon/human/human_update_on = update_on
+				human_update_on.apply_height_offsets(emissive_right, TRUE)
+				human_update_on.apply_height_offsets(emissive_left, TRUE)
+			// OCULIS EDIT ADDITION END
+
 			eye_left.overlays += emissive_left
 			eye_right.overlays += emissive_right
 		// NOVA EDIT ADDITION END


### PR DESCRIPTION

## About The Pull Request

This makes it so eye emissives are properly offset with height. Simple as that.

## Why it's Good for the Game

fix is good lol

## Proof of Testing

<img width="146" height="165" alt="image" src="https://github.com/user-attachments/assets/308aafdb-56c4-4bd9-a092-51edbfd78419" />

## Changelog
:cl:
fix: Eye emissive sprites are now properly aligned on characters with different heights.
/:cl:
