### PR TITLE
Soft-spoken trait no longer applies to radio messages

### DIFF
--- a/code/modules/mob/living/living_say.dm
+++ b/code/modules/mob/living/living_say.dm
@@ -161,8 +161,10 @@ GLOBAL_LIST_INIT(message_modes_stat_limits, list(
 			say_dead(original_message, message_mods[MANNEQUIN_CONTROLLED])
 			return
 
+	/* // OCULIS EDIT REMOVAL START - Moved to be after radios.
 	if(HAS_TRAIT(src, TRAIT_SOFTSPOKEN) && !HAS_TRAIT(src, TRAIT_SIGN_LANG)) // softspoken trait only applies to spoken languages
 		message_mods[WHISPER_MODE] = MODE_WHISPER
+	*/ // OCULIS EDIT REMOVAL END
 
 	if(client && SSlag_switch.measures[SLOWMODE_SAY] && !HAS_TRAIT(src, TRAIT_BYPASS_MEASURES) && !forced && src == usr)
 		if(!COOLDOWN_FINISHED(client, say_slowmode))
@@ -243,6 +245,14 @@ GLOBAL_LIST_INIT(message_modes_stat_limits, list(
 	var/radio_return = radio(message, message_mods, spans, language)//roughly 27% of living/say()'s total cost
 	if(radio_return & NOPASS)
 		return TRUE
+
+	// OCULIS EDIT ADDITION START: moved softspoken check to after radio
+	if(HAS_TRAIT(src, TRAIT_SOFTSPOKEN) && !HAS_TRAIT(src, TRAIT_SIGN_LANG) && !message_mods[WHISPER_MODE]) // softspoken trait only applies to spoken languages
+		message_range = 1
+		message_mods[WHISPER_MODE] = MODE_WHISPER
+		message_mods[SAY_MOD_VERB] = say_mod(message, message_mods)
+		spans |= SPAN_ITALICS
+	// OCULIS EDIT ADDITION END
 
 	if(radio_return & ITALICS)
 		spans |= SPAN_ITALICS


### PR DESCRIPTION

## About The Pull Request

Ports https://github.com/Monkestation/Monkestation2.0/pull/2330

> Makes whispering caused by the soft-spoken trait no longer apply to radio messages.

## Why it's Good for the Game

> The idea of soft spoken is that you can't talk to people without going close to them.
> Not being able to talk on radios makes sense, but it's just not fun gameplay wise.
> I can't walk across the map to the other department at all times, even if I wanted to.
> Thus, I feel like the "basically can't use radio" part is too debilitating for a -2 trait.
> 
> Side note, whispering on radios is weird and uses stars() twice, making the message completely incomprehensible.
> The first stars() is when you say the message and the second stars() is when others hear it.

## Proof of Testing

<img width="584" height="105" alt="2026-03-01 (1772424009) ~ dreamseeker" src="https://github.com/user-attachments/assets/f83aec78-1c78-4b38-ba8f-b95cd2922677" />

## Changelog
:cl:
balance: Soft-spoken no longer affects radio messages.
/:cl:
