### PR TITLE
adds extra text for baring fangs with venomous bite

### DIFF
--- a/modular_nova/master_files/code/datums/quirks/positive_quirks/venomous/venomous_bite.dm
+++ b/modular_nova/master_files/code/datums/quirks/positive_quirks/venomous/venomous_bite.dm
@@ -42,7 +42,10 @@
 	if (!.)
 		return
 
-	owner.visible_message("[owner] bares [owner.p_their()] fangs...", span_warning("You bare your fangs..."))
+	// OCULIS EDIT ADDITION START - extra flavor messages
+	owner.visible_message(span_warning("[owner] bares [owner.p_their()] fangs..."), span_warning("You bare your fangs..."))
+	owner.balloon_alert_to_viewers("bares [owner.p_their()] fangs")
+	// OCULIS EDIT ADDITION END
 
 /datum/action/cooldown/mob_cooldown/venomous_bite/Activate(atom/target_atom)
 	if (!isliving(target_atom))


### PR DESCRIPTION

## About The Pull Request

this adds a "bares their fangs" balloon alert to activating the venomous bite click ability, alongside adding an actual span to the visible message

## Why it's Good for the Game

So I can intimidate people during petty arguments by threatening to bite them.

## Proof of Testing

![2026-03-02 (1772493387) ~ dreamseeker](https://github.com/user-attachments/assets/b068f3c7-77bf-4080-8a3c-86616dbf3419)

## Changelog
:cl:
add: Activating Venomous Bite now has a balloon alert
/:cl:
