### PR TITLE
fixes a minor hard delete in examine panels

### DIFF
--- a/modular_nova/master_files/code/modules/mob/living/examine_tgui.dm
+++ b/modular_nova/master_files/code/modules/mob/living/examine_tgui.dm
@@ -9,14 +9,14 @@
 
 /datum/examine_panel/Destroy(force)
 	holder = null
-	QDEL_NULL(examine_panel_screen)
+	QDEL_NULL(examine_panel_screen) // OCULIS EDIT CHANGE - ORIGINAL: qdel(examine_panel_screen)
 	return ..()
 
 /datum/examine_panel/ui_state(mob/user)
 	return GLOB.always_state
 
 /datum/examine_panel/ui_close(mob/user)
-	examine_panel_screen.hide_from(user)
+	examine_panel_screen.hide_from(user) // OCULIS EDIT CHANGE - ORIGINAL: user.client?.clear_map(examine_panel_screen.assigned_map)
 
 /atom/movable/screen/map_view/examine_panel_screen
 	name = "examine panel screen"


### PR DESCRIPTION

## About The Pull Request

this makes it so examine panels properly set their `examine_panel_screen` var to null after qdeling them in Destroy

also uses `hide_from` in `ui_close`, as you shouldn't use `clear_map` directly.

this doesn't fix them being broken, just fixes a potential hard delete.

## Why it's Good for the Game

hard deletes bad

## Proof of Testing

it's setting a var to null in Destroy, you can't really screenshot that

## Changelog

No player-facing changes