### PR TITLE
Avoid Regenerating Character Previews Unnecessarily

### DIFF
--- a/code/modules/client/preferences/_preference.dm
+++ b/code/modules/client/preferences/_preference.dm
@@ -297,7 +297,7 @@ GLOBAL_LIST_INIT(preference_entries_by_key, init_preference_entries_by_key())
 
 	if (preference.savefile_identifier == PREFERENCE_PLAYER)
 		preference.apply_to_client_updated(parent, read_preference(preference.type))
-	else
+	else if (preference.should_update_preview) // OCULIS EDIT CHANGE, ORIGINAL: else
 		character_preview_view?.update_body()
 
 	return TRUE

--- a/code/modules/client/preferences/food_allergy.dm
+++ b/code/modules/client/preferences/food_allergy.dm
@@ -3,6 +3,7 @@
 	savefile_key = "food_allergy"
 	savefile_identifier = PREFERENCE_CHARACTER
 	can_randomize = FALSE
+	should_update_preview = FALSE // OCULIS EDIT ADDITION
 
 /datum/preference/choiced/food_allergy/init_possible_values()
 	return list("Random") + assoc_to_keys(GLOB.possible_food_allergies)

--- a/code/modules/client/preferences/language.dm
+++ b/code/modules/client/preferences/language.dm
@@ -3,6 +3,7 @@
 	savefile_key = "language"
 	savefile_identifier = PREFERENCE_CHARACTER
 	should_generate_icons = TRUE
+	should_update_preview = FALSE // OCULIS EDIT ADDITION
 
 /datum/preference/choiced/language/create_default_value()
 	return "Random"

--- a/code/modules/client/preferences/operative_species.dm
+++ b/code/modules/client/preferences/operative_species.dm
@@ -6,6 +6,7 @@
 	default_value = TRUE
 	savefile_identifier = PREFERENCE_CHARACTER
 	savefile_key = "operative_species"
+	should_update_preview = FALSE // OCULIS EDIT ADDITION
 
 /datum/preference/toggle/nuke_ops_species/is_accessible(datum/preferences/preferences)
 	. = ..()

--- a/code/modules/client/preferences/paint_color.dm
+++ b/code/modules/client/preferences/paint_color.dm
@@ -3,6 +3,7 @@
 	savefile_key = "paint_color"
 	savefile_identifier = PREFERENCE_CHARACTER
 	category = PREFERENCE_CATEGORY_MANUALLY_RENDERED
+	should_update_preview = FALSE // OCULIS EDIT ADDITION
 
 /datum/preference/color/paint_color/is_accessible(datum/preferences/preferences)
 	if (!..(preferences))

--- a/code/modules/client/preferences/pda.dm
+++ b/code/modules/client/preferences/pda.dm
@@ -8,7 +8,7 @@
 	category = PREFERENCE_CATEGORY_NON_CONTEXTUAL
 	savefile_identifier = PREFERENCE_CHARACTER
 	maximum_value_length = MESSENGER_RINGTONE_MAX_LENGTH
-
+	should_update_preview = FALSE // OCULIS EDIT ADDITION
 
 /datum/preference/text/pda_ringtone/create_default_value()
 	return MESSENGER_RINGTONE_DEFAULT
@@ -24,6 +24,7 @@
 	savefile_key = "pda_theme"
 	category = PREFERENCE_CATEGORY_NON_CONTEXTUAL
 	savefile_identifier = PREFERENCE_CHARACTER
+	should_update_preview = FALSE // OCULIS EDIT ADDITION
 
 /datum/preference/choiced/pda_theme/init_possible_values()
 	var/list/values = list()

--- a/code/modules/client/preferences/phobia.dm
+++ b/code/modules/client/preferences/phobia.dm
@@ -2,6 +2,7 @@
 	category = PREFERENCE_CATEGORY_MANUALLY_RENDERED
 	savefile_key = "phobia"
 	savefile_identifier = PREFERENCE_CHARACTER
+	should_update_preview = FALSE // OCULIS EDIT ADDITION
 
 /datum/preference/choiced/phobia/init_possible_values()
 	return GLOB.phobia_types

--- a/code/modules/client/preferences/prisoner_crime.dm
+++ b/code/modules/client/preferences/prisoner_crime.dm
@@ -3,6 +3,7 @@
 	category = PREFERENCE_CATEGORY_NON_CONTEXTUAL
 	savefile_identifier = PREFERENCE_CHARACTER
 	savefile_key = "prisoner_crime"
+	should_update_preview = FALSE // OCULIS EDIT ADDITION
 
 /datum/preference/choiced/prisoner_crime/init_possible_values()
 	return assoc_to_keys(GLOB.prisoner_crimes) + "Random"
@@ -98,7 +99,7 @@ GLOBAL_LIST_INIT(prisoner_crimes, init_prisoner_crimes())
 	name = "Identity Theft of High-Ranking Figure"
 	desc = "Impersonated a high-ranking figure."
 	tattoos = 0 //well, obviously can't impersonate people with tats. if they want to go back to doing that
-	
+
 /datum/prisoner_crime/jaywalker
 	name = "Jaywalker"
 	desc = "Jaywalked across non-green tram crossings, shuttle docking zones, and/or through space."

--- a/code/modules/client/preferences/security_department.dm
+++ b/code/modules/client/preferences/security_department.dm
@@ -4,6 +4,7 @@
 	can_randomize = FALSE
 	savefile_identifier = PREFERENCE_CHARACTER
 	savefile_key = "prefered_security_department"
+	should_update_preview = FALSE // OCULIS EDIT ADDITION
 
 // This is what that #warn wants you to remove :)
 /datum/preference/choiced/security_department/deserialize(input, datum/preferences/preferences)

--- a/code/modules/client/preferences/uplink_location.dm
+++ b/code/modules/client/preferences/uplink_location.dm
@@ -3,6 +3,7 @@
 	savefile_identifier = PREFERENCE_CHARACTER
 	savefile_key = "uplink_loc"
 	can_randomize = FALSE
+	should_update_preview = FALSE // OCULIS EDIT ADDITION
 
 /datum/preference/choiced/uplink_location/init_possible_values()
 	return list(UPLINK_PDA, UPLINK_RADIO, UPLINK_PEN, UPLINK_IMPLANT)

--- a/modular_iris/modules/quirks/tunnel_vision.dm
+++ b/modular_iris/modules/quirks/tunnel_vision.dm
@@ -33,6 +33,7 @@ GLOBAL_LIST_INIT(tunnel_vision_fovs, list("Minor (90 Degrees)","Moderate (180 De
 	category = PREFERENCE_CATEGORY_MANUALLY_RENDERED
 	savefile_key = "tunnel_vision_fov"
 	savefile_identifier = PREFERENCE_CHARACTER
+	should_update_preview = FALSE // OCULIS EDIT ADDITION
 
 /datum/preference/choiced/tunnel_vision_fov/init_possible_values()
 	return GLOB.tunnel_vision_fovs

--- a/modular_nova/master_files/code/modules/client/preferences/flavor_text.dm
+++ b/modular_nova/master_files/code/modules/client/preferences/flavor_text.dm
@@ -3,6 +3,7 @@
 	savefile_identifier = PREFERENCE_CHARACTER
 	savefile_key = "flavor_text"
 	maximum_value_length = MAX_FLAVOR_LEN
+	should_update_preview = FALSE // OCULIS EDIT ADDITION
 
 /datum/preference/text/flavor_text/apply_to_human(mob/living/carbon/human/target, value, datum/preferences/preferences)
 	target.dna.features[EXAMINE_DNA_FLAVOR_TEXT] = value
@@ -14,6 +15,7 @@
 	savefile_identifier = PREFERENCE_CHARACTER
 	savefile_key = "silicon_flavor_text"
 	maximum_value_length = MAX_FLAVOR_LEN
+	should_update_preview = FALSE // OCULIS EDIT ADDITION
 
 /datum/preference/text/silicon_flavor_text/apply_to_human(mob/living/carbon/human/target, value, datum/preferences/preferences)
 	return FALSE // To prevent the not-implemented runtime
@@ -23,6 +25,7 @@
 	savefile_identifier = PREFERENCE_CHARACTER
 	savefile_key = "ooc_notes"
 	maximum_value_length = MAX_FLAVOR_LEN
+	should_update_preview = FALSE // OCULIS EDIT ADDITION
 
 /datum/preference/text/ooc_notes/apply_to_human(mob/living/carbon/human/target, value, datum/preferences/preferences)
 	target.dna.features[EXAMINE_DNA_OOC_NOTES] = value
@@ -32,6 +35,7 @@
 	savefile_identifier = PREFERENCE_CHARACTER
 	savefile_key = "custom_species"
 	maximum_value_length = 100
+	should_update_preview = FALSE // OCULIS EDIT ADDITION
 
 /datum/preference/text/custom_species/apply_to_human(mob/living/carbon/human/target, value, datum/preferences/preferences)
 	target.dna.features["custom_species"] = value
@@ -48,6 +52,7 @@
 	savefile_identifier = PREFERENCE_CHARACTER
 	savefile_key = "custom_species_lore"
 	maximum_value_length = MAX_FLAVOR_LEN
+	should_update_preview = FALSE // OCULIS EDIT ADDITION
 
 /datum/preference/text/custom_species_lore/apply_to_human(mob/living/carbon/human/target, value, datum/preferences/preferences)
 	target.dna.features["custom_species_lore"] = value
@@ -66,6 +71,7 @@
 	savefile_identifier = PREFERENCE_CHARACTER
 	savefile_key = "general_record"
 	maximum_value_length = MAX_FLAVOR_LEN
+	should_update_preview = FALSE // OCULIS EDIT ADDITION
 
 /datum/preference/text/general/apply_to_human(mob/living/carbon/human/target, value, datum/preferences/preferences)
 	return FALSE
@@ -75,6 +81,7 @@
 	savefile_identifier = PREFERENCE_CHARACTER
 	savefile_key = "medical_record"
 	maximum_value_length = MAX_FLAVOR_LEN
+	should_update_preview = FALSE // OCULIS EDIT ADDITION
 
 /datum/preference/text/medical/apply_to_human(mob/living/carbon/human/target, value, datum/preferences/preferences)
 	return FALSE
@@ -84,6 +91,7 @@
 	savefile_identifier = PREFERENCE_CHARACTER
 	savefile_key = "security_record"
 	maximum_value_length = MAX_FLAVOR_LEN
+	should_update_preview = FALSE // OCULIS EDIT ADDITION
 
 /datum/preference/text/security/apply_to_human(mob/living/carbon/human/target, value, datum/preferences/preferences)
 	return FALSE
@@ -93,6 +101,7 @@
 	savefile_identifier = PREFERENCE_CHARACTER
 	savefile_key = "exploitable_info"
 	maximum_value_length = MAX_FLAVOR_LEN
+	should_update_preview = FALSE // OCULIS EDIT ADDITION
 
 /datum/preference/text/exploitable/create_default_value()
 	return EXPLOITABLE_DEFAULT_TEXT
@@ -105,6 +114,7 @@
 	savefile_identifier = PREFERENCE_CHARACTER
 	savefile_key = "background_info"
 	maximum_value_length = MAX_FLAVOR_LEN
+	should_update_preview = FALSE // OCULIS EDIT ADDITION
 
 /datum/preference/text/background/apply_to_human(mob/living/carbon/human/target, value, datum/preferences/preferences)
 	return FALSE

--- a/modular_oculis/master_files/code/modules/client/preferences/_preference.dm
+++ b/modular_oculis/master_files/code/modules/client/preferences/_preference.dm
@@ -1,0 +1,4 @@
+/datum/preference
+	/// If this is a character preference, should we update the character preview
+	/// when this preference is updated?
+	var/should_update_preview = TRUE

--- a/tgstation.dme
+++ b/tgstation.dme
@@ -9888,6 +9888,7 @@
 #include "modular_oculis\master_files\code\modules\admin\verbs\getlogs.dm"
 #include "modular_oculis\master_files\code\modules\client\client_procs.dm"
 #include "modular_oculis\master_files\code\modules\client\persistent_client.dm"
+#include "modular_oculis\master_files\code\modules\client\preferences\_preference.dm"
 #include "modular_oculis\master_files\code\modules\client\preferences\admin.dm"
 #include "modular_oculis\master_files\code\modules\client\preferences\ooc.dm"
 #include "modular_oculis\master_files\code\modules\client\preferences\sounds.dm"


### PR DESCRIPTION

## About The Pull Request
Manual mirror of https://github.com/Monkestation/Monkestation2.0/pull/10634

## Why it's Good for the Game

you shouldnt regenerate when you dont have to.

## Proof of Testing
<img width="604" height="295" alt="image" src="https://github.com/user-attachments/assets/9001899c-c48b-455d-8443-7099ce146228" />

<img width="920" height="780" alt="image" src="https://github.com/user-attachments/assets/90d84d03-cbac-40e8-907a-60c9f580d1d1" />

## Changelog
:cl:
/:cl:
