### PR TITLE
Margherita custom slice ingredient holder fix

### DIFF
--- a/code/game/objects/items/food/pizza.dm
+++ b/code/game/objects/items/food/pizza.dm
@@ -185,7 +185,7 @@
 /obj/item/food/pizzaslice/margherita/Initialize(mapload)
 	. = ..()
 	// OCULIS EDIT START - ingredient holder won't change custom slices to the default slice
-	AddComponent( /datum/component/ingredients_holder, /obj/item/food/pizzaslice/margherita, CUSTOM_INGREDIENT_ICON_FILL, max_ingredients = 12 )
+	AddComponent(/datum/component/ingredients_holder, /obj/item/food/pizzaslice/margherita, CUSTOM_INGREDIENT_ICON_FILL, max_ingredients = 12)
 	// OCULIS EDIT END
 
 /obj/item/food/pizza/meat


### PR DESCRIPTION
See line 187-189
## About The Pull Request
Fixes margherita slices so that they don't default to the generic pizza slice
## Why it's Good for the Game
Removes the bugged state from custom slices
## Proof of Testing

To test:
1. Spawn /obj/item/food/pizzaslice/margherita
<img width="231" height="52" alt="image" src="https://github.com/user-attachments/assets/1f82125c-c616-4b4e-ae89-8e0f055cd877" />

2. View variables and click on the ingredient_holder datum to verify it's initialized properly
<img width="459" height="608" alt="image" src="https://github.com/user-attachments/assets/fb75026a-97f3-406c-842f-ef561cc53179" />

3. Spawn any /obj/item/food that the holder can contain and add it to the custom slice
4. The slice should retain its previous description and icon state, the only thing that has to change is the overlay
<img width="330" height="38" alt="image" src="https://github.com/user-attachments/assets/7d0cf910-5c75-47fc-80a3-e233bc50a26e" />
<img width="509" height="148" alt="image" src="https://github.com/user-attachments/assets/97a8f870-ff37-4ec5-9b82-ea834a1451b9" />

## Changelog
:cl: Deadindamind
fix: custom margherita slices no longer default to an error icon
/:cl:
