### PR TITLE
raise collect_data action timeout to 15 minutes

### DIFF
--- a/.github/workflows/collect_data.yml
+++ b/.github/workflows/collect_data.yml
@@ -22,7 +22,7 @@ on:
 jobs:
   collect_data:
     runs-on: ubuntu-24.04
-    timeout-minutes: 5
+    timeout-minutes: 15 # OCULIS EDIT CHANGE - ORIGINAL: timeout-minutes: 5
     outputs:
       maps: ${{ steps.map_finder.outputs.maps }}
       alternate_tests: ${{ steps.alternate_test_finder.outputs.alternate_tests }}


### PR DESCRIPTION

## About The Pull Request

raises the `collect_data` unit test timeout to 15 mins, bc it likes to time out cloning the repo for some stupid reason.

## Why it's Good for the Game

I AM TIRED OF CI TESTS FAILING BC GITHUB WANTS TO BE SLOW

## Proof of Testing

N/A

## Changelog

zero in-game changes