### PR TITLE
Allow mining scanners to fit in boots.

### DIFF
--- a/code/datums/storage/subtypes/pockets.dm
+++ b/code/datums/storage/subtypes/pockets.dm
@@ -129,6 +129,10 @@
 			/obj/item/ammo_box/magazine/m9mm_aps,
 			/obj/item/ammo_box/magazine/toy/pistol,
 			// NOVA EDIT ADDITION END
+			// OCULIS EDIT ADDITION START
+			/obj/item/t_scanner/adv_mining_scanner,
+			/obj/item/t_scanner/adv_mining_scanner/lesser,
+			// OCULIS EDIT ADDITION END
 		),
 		cant_hold_list = list(
 			/obj/item/screwdriver/power,


### PR DESCRIPTION

## About The Pull Request

exactly what it says on the tin - mining scanners now fit in boots.

## Why it's Good for the Game

Less inventory management hell.

## Proof of Testing

<img width="911" height="1043" alt="image" src="https://github.com/user-attachments/assets/920d1e62-b00b-4e74-9335-d0e21cbb8aa5" />

## Changelog
:cl:
balance: Mining scanners now fit in boots.
/:cl:
