### PR TITLE
prevent `apply_height_filters` from spamming runtime logs with the same thing 500 times

### DIFF
--- a/code/modules/mob/living/carbon/human/human_update_icons.dm
+++ b/code/modules/mob/living/carbon/human/human_update_icons.dm
@@ -1376,6 +1376,10 @@ mutant_styles: The mutant style - taur bodytype, STYLE_TESHARI, etc. // NOVA EDI
 */ // IRIS EDIT REMOVAL END
 
 	// IRIS EDIT ADDITION START - Height-based displacement masks.
+	var/static/list/screamed_icons
+	if(isnull(screamed_icons))
+		screamed_icons = list()
+
 	var/list/dims = get_icon_dimensions(appearance.icon)
 	var/icon_width = dims["width"]
 	var/icon_height = dims["height"]
@@ -1387,7 +1391,9 @@ mutant_styles: The mutant style - taur bodytype, STYLE_TESHARI, etc. // NOVA EDI
 		else if(icon_height == 64 && icon_width <= 64)
 			mask_icon = 'modular_iris/icons/effects/cut_64x64.dmi'
 		else if(icon_height != 32 || icon_width > 32)
-			stack_trace("Bad dimensions (w[icon_width],h[icon_height]) for icon '[appearance.icon]'")
+			if(!(appearance.icon in screamed_icons)) // only throw one runtime per icon
+				stack_trace("Bad dimensions (w[icon_width],h[icon_height]) for icon '[appearance.icon]'")
+				screamed_icons += appearance.icon
 
 	// Move the filter up if the image has been moved down, and vice versa
 	var/adjust_y = -appearance.pixel_y - parent_adjust_y


### PR DESCRIPTION
exactly what it says on the tin
i only need to see this once in the runtime log, not like 500 different times:
```
[2026-03-09 21:20:53.400] RUNTIME: runtime error: Bad dimensions (w64,h32) for icon 'modular_nova/master_files/icons/mob/sprite_accessory/taur.dmi'
 - proc name:  stack trace (/proc/_stack_trace)
 -   source file: code/__HELPERS/stack_trace.dm,4
 -   usr: [removed] (/mob/dead/new_player)
 -   src: null
 -   usr.loc: the cordon (198,164,1) (/turf/cordon)
 -   call stack:
 -  stack trace("Bad dimensions (w64,h32) for i...", "code/modules/mob/living/carbon...", 1390)
```
so yeah it will only runtime once per icon, because this makes going thru runtime logs misery:
<img width="457" height="65" alt="image" src="https://github.com/user-attachments/assets/f8cfd14f-c532-42bf-9eed-8b46447df137" />
