### PR TITLE
Fixes the sisyphus achievement

### DIFF
--- a/code/datums/components/sisyphus_awarder.dm
+++ b/code/datums/components/sisyphus_awarder.dm
@@ -46,8 +46,8 @@
 	if (atom_parent.loc != chosen_one)
 		qdel(src) // Hey! How did you do that?
 		return
-//	if (entered_area.type != /area/centcom/central_command_areas/evacuation) // IRIS EDIT OLD
-	if(!istype(entered_area, /area/centcom/interlink/departures)) // IRIS EDIT NEW (also by the way pods dont come to the interlink)
+//	if (entered_area.type != /area/centcom/central_command_areas/evacuation) // OCULIS EDIT OLD
+	if (entered_area.type != /area/centcom/castor/evacuation) // OCULIS EDIT NEW
 		return // Don't istype because taking pods doesn't count
 
 	chosen_one.client?.give_award(/datum/award/achievement/misc/sisyphus, chosen_one)


### PR DESCRIPTION

## About The Pull Request

- Because we needed our own centcom evacuation area breaking every single piece of code related to the old evac areas, fixes the sisyphus achievement

## Why it's Good for the Game

> Because we needed our own centcom evacuation area breaking every single piece of code related to the old evac areas, fixes the sisyphus achievement
- Achievements being obtainable is cool
- Fixes: #94

## Proof of Testing

<img width="1600" height="857" alt="image" src="https://github.com/user-attachments/assets/83fe5307-71fc-4968-af6a-bc39faa8f262" />

## Changelog

:cl:
fix: the sisyphus achievement works as intended on TG now
/:cl:
