### PR TITLE
[EARLY CHERRY-PICK] Revert "github actions only fire when it's meaningful to do so"

### DIFF
--- a/.github/workflows/ci_suite.yml
+++ b/.github/workflows/ci_suite.yml
@@ -33,7 +33,6 @@ jobs:
     uses: ./.github/workflows/collect_data.yml
 
   compile_all_maps:
-    if: needs.collect_data.outputs.game_changes == 'true'
     name: Compile Maps
     needs: collect_data
     uses: ./.github/workflows/compile_all_maps.yml
@@ -41,7 +40,6 @@ jobs:
       max_required_byond_client: ${{ needs.collect_data.outputs.max_required_byond_client }}
 
   setup_build_artifacts:
-    if: needs.collect_data.outputs.game_changes == 'true'
     name: Setup build artifacts
     needs: collect_data
     uses: ./.github/workflows/setup_build_artifacts.yml
@@ -49,7 +47,6 @@ jobs:
       build_versions: ${{ needs.collect_data.outputs.required_build_versions }}
 
   run_all_tests:
-    if: needs.collect_data.outputs.game_changes == 'true'
     name: Integration Tests
     needs: [collect_data, setup_build_artifacts]
     uses: ./.github/workflows/perform_regular_version_tests.yml
@@ -58,7 +55,7 @@ jobs:
       max_required_byond_client: ${{ needs.collect_data.outputs.max_required_byond_client }}
 
   run_alternate_tests:
-    if: (needs.collect_data.outputs.game_changes == 'true') && (needs.collect_data.outputs.alternate_tests != '[]')
+    if: needs.collect_data.outputs.alternate_tests != '[]'
     name: Alternate Tests
     needs: [collect_data, setup_build_artifacts]
     uses: ./.github/workflows/perform_alternate_version_tests.yml
@@ -89,4 +86,4 @@ jobs:
         uses: re-actors/alls-green@release/v1
         with:
           jobs: ${{ toJSON(needs) }}
-          allowed-skips: compare_screenshots,compile_all_maps,run_all_tests,run_alternate_tests
+          allowed-skips: compare_screenshots

--- a/.github/workflows/collect_data.yml
+++ b/.github/workflows/collect_data.yml
@@ -15,9 +15,6 @@ on:
       required_build_versions:
         description: "Build versions that need to be precompiled"
         value: ${{ jobs.collect_data.outputs.required_build_versions }}
-      game_changes:
-        description: "Whether game files were changed"
-        value: ${{ jobs.collect_data.outputs.game_changes }}
 
 jobs:
   collect_data:
@@ -28,7 +25,6 @@ jobs:
       alternate_tests: ${{ steps.alternate_test_finder.outputs.alternate_tests }}
       max_required_byond_client: ${{ steps.max_required_byond_client.outputs.max_required_byond_client }}
       required_build_versions: ${{ steps.setup_required_build_versions.outputs.required_build_versions }}
-      game_changes: ${{ steps.find_game_changes.outputs.all_changed_files != '' }}
 
     steps:
       - uses: actions/checkout@v6
@@ -70,13 +66,3 @@ jobs:
             ($alternate + $default) | map({major, minor}) | unique
           ')
           echo "required_build_versions=$REQUIRED_BUILD_VERSIONS" >> $GITHUB_OUTPUT
-
-      - name: Find game changes
-        id: find_game_changes
-        uses: tj-actions/changed-files@v47
-        with:
-          fetch_depth: 0
-          files_ignore: |
-            **/*.md
-            html/**
-            tgui/**

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -14,7 +14,7 @@
 		"editor.formatOnSave": true,
 		"editor.rulers": [80]
 	},
-	"[yaml][markdown][html][scss][github-actions-workflow]": {
+	"[yaml][markdown][html][scss]": {
 		"editor.defaultFormatter": "esbenp.prettier-vscode",
 		"editor.formatOnSave": true,
 		"editor.rulers": [80]


### PR DESCRIPTION
early cherry-pick of https://github.com/tgstation/tgstation/pull/95059

while this is included in https://github.com/Monkestation/OculisStation/pull/57, i'd really prefer CI work consistently without waiting for that PR to be fixed and testmerged.