### PR TITLE
Fix syndicate comms not working

### DIFF
--- a/_maps/map_files/generic/CentCom_oculis.dmm
+++ b/_maps/map_files/generic/CentCom_oculis.dmm
@@ -22598,6 +22598,10 @@
 	},
 /turf/open/floor/iron/dark/smooth_large,
 /area/centcom/central_command_areas/armory)
+"wxQ" = (
+/obj/machinery/telecomms/allinone/nuclear,
+/turf/open/floor/iron/smooth,
+/area/centcom/interlink)
 "wyd" = (
 /obj/structure/railing/wooden_fencing{
 	dir = 8
@@ -44720,10 +44724,10 @@ ubO
 ubO
 ard
 ard
-ard
 npX
 ard
 ard
+jXJ
 ard
 gAu
 xrR
@@ -44980,8 +44984,8 @@ ard
 ard
 ard
 ard
-ard
-ard
+jXJ
+wxQ
 gAu
 iHq
 axv
@@ -45234,10 +45238,10 @@ ubO
 ubO
 ard
 ard
-ard
 lLY
 ard
 ard
+jXJ
 ard
 gAu
 xfS


### PR DESCRIPTION

## About The Pull Request

lmao turns out syndie comms relies on a hidden allinone telecomms mainframe at centcom. which centcom_oculis did not have. so i added it.

Fixes https://github.com/Monkestation/OculisStation/issues/82

## Why it's Good for the Game

bugfix

## Proof of Testing

<img width="338" height="57" alt="image" src="https://github.com/user-attachments/assets/b85ce1d7-72c8-4eec-b77d-4e32e53f6cd3" />


## Changelog
:cl:
fix: Syndicate comms now actually works.
/:cl:
