### PR TITLE
Generate changelogs every day

### DIFF
--- a/.github/workflows/compile_changelogs.yml
+++ b/.github/workflows/compile_changelogs.yml
@@ -2,7 +2,7 @@ name: Compile changelogs
 
 on:
   schedule:
-    - cron: "0 0 * * 1"
+    - cron: "0 0 * * *" # OCULIS EDIT CHANGE - ORIGINAL: - cron: "0 0 * * 1"
   workflow_dispatch:
 
 jobs:


### PR DESCRIPTION
Modular revert of https://github.com/Monkestation/OculisStation/commit/1189c750d3e0cc2db750976789e52a7231b48ede

We don't have TGS setup to run the workflow automatically, so we should use the old behavior (running daily)