### PR TITLE
Lets drones slide under doors again.

### DIFF
--- a/modular_nova/modules/drones/slide_component.dm
+++ b/modular_nova/modules/drones/slide_component.dm
@@ -24,10 +24,12 @@
 /datum/element/sliding_under/proc/check_conditions(datum/source, mob/user)
 	SIGNAL_HANDLER
 
+	//OCULIS EDIT START
 	if(!isatom(source))
 		return
 
 	var/atom/source_atom = source
+	//OCULIS EDIT END
 
 	//the parent needs to be dense in order to slide through
 	if(!source_atom.density)
@@ -55,7 +57,7 @@
 /datum/element/sliding_under/proc/ExamineMessage(datum/source, mob/user, list/examine_list)
 	SIGNAL_HANDLER
 
-	if(!is_type_in_typecache(user, allowed_mobs))
+	if(!is_type_in_typecache(user, allowed_mobs)) // OCULIS EDIT: allowed_mobs is a typecache why were they using is_type_in_list? original: if(!is_type_in_list(user, allowed_mobs))
 		return
 
 	examine_list += span_warning("Ctrl + Click [source] to slide under!\n")


### PR DESCRIPTION

## About The Pull Request
Drones have a slide component that should allow them to slide under doors:
<img width="363" height="123" alt="image" src="https://github.com/user-attachments/assets/94100e98-4947-4719-8db9-b9238a867158" />
This is currently a LIE. Drones are forever beholden to the same door restrictions as anyone else!

This PR aims to correct this absolutely disgusting oversight.

## Why it's Good for the Game
DRONES FOREVER. Also making things work as they should, I guess.

## Proof of Testing
https://github.com/user-attachments/assets/a4fc10ed-51de-4669-ac6b-36e0a3e5f8fe


## Changelog
:cl:
fix: Drones can now slide under doors again.
/:cl:
