### PR TITLE
Adds A Few Job Coats & Coroner Clothes To Loadout

### DIFF
--- a/modular_oculis/modules/loadouts/loadout_items/loadout_datum_suit.dm
+++ b/modular_oculis/modules/loadouts/loadout_items/loadout_datum_suit.dm
@@ -1,0 +1,19 @@
+/datum/loadout_item/suit/coat_chemistry
+	name = "Winter Coat - Chemistry"
+	item_path = /obj/item/clothing/suit/hooded/wintercoat/medical/chemistry
+
+/datum/loadout_item/suit/coat_coroner
+	name = "Winter Coat - Coroner"
+	item_path = /obj/item/clothing/suit/hooded/wintercoat/medical/coroner
+
+/datum/loadout_item/suit/coat_genetics
+	name = "Winter Coat - Genetics"
+	item_path = /obj/item/clothing/suit/hooded/wintercoat/science/genetics
+
+/datum/loadout_item/suit/coat_janitor
+	name = "Winter Coat - Janitor"
+	item_path = /obj/item/clothing/suit/hooded/wintercoat/janitor
+
+/datum/loadout_item/suit/coat_virology
+	name = "Winter Coat - Virology"
+	item_path = /obj/item/clothing/suit/hooded/wintercoat/medical/viro

--- a/modular_oculis/modules/loadouts/loadout_items/under/loadout_datum_under_job.dm
+++ b/modular_oculis/modules/loadouts/loadout_items/under/loadout_datum_under_job.dm
@@ -1,0 +1,14 @@
+/*
+*	WORKWEAR
+*	For job gear or otherwise work-related attire. PPE, Department Equipment, or Job-Locked.
+*/
+
+/datum/loadout_item/under/jumpsuit/coroner_jumpskirt
+	name = "Coroner Jumpskirt"
+	item_path = /obj/item/clothing/under/rank/medical/coroner/skirt
+	group = "Workwear"
+
+/datum/loadout_item/under/jumpsuit/coroner_jumpsuit
+	name = "Coroner Jumpsuit"
+	item_path = /obj/item/clothing/under/rank/medical/coroner
+	group = "Workwear"

--- a/tgstation.dme
+++ b/tgstation.dme
@@ -9940,6 +9940,8 @@
 #include "modular_oculis\modules\GAGS\greyscale_configs\neck.dm"
 #include "modular_oculis\modules\hairstyles\code\hair.dm"
 #include "modular_oculis\modules\loadouts\loadout_items\loadout_datum_neck.dm"
+#include "modular_oculis\modules\loadouts\loadout_items\loadout_datum_suit.dm"
+#include "modular_oculis\modules\loadouts\loadout_items\under\loadout_datum_under_job.dm"
 #include "modular_oculis\modules\lobby_notices\code\lobby_notices.dm"
 #include "modular_oculis\modules\memorystats\code\memorystats.dm"
 #include "modular_oculis\modules\mining\mega_respawning\flute_recipes.dm"


### PR DESCRIPTION

## About The Pull Request
Adds the chemist, coroner, genetics, janitor, and virologist wintercoats to loadout.
Also adds the coroner's jumpskirt and jumpsuit.
## Why it's Good for the Game
Requested on the discord
<img width="851" height="368" alt="image" src="https://github.com/user-attachments/assets/8e8b6dcd-e461-47c6-aa4c-089f74ffa472" />


I don't see the harm in it. Technically we have the transformative wintercoat, which removes the point of adding these, but like. By its very nature it cannot render in the character creator, which defeats the purpose of playing dress up to begin with.

I specifically _didn't_ add the command wintercoats as joblocked options, as it seems to have been a deliberate decision on nova's part for balancing sake, something about keeping them limited by design. 
## Proof of Testing
![winter coats + coroner](https://github.com/user-attachments/assets/039694f8-858c-4ff0-8011-07c52c6bccb3)
ᶜᵘʳˢᵒʳ ᶦⁿ ᵍᶦᶠ
ᵏᶦˡˡ ᵗʰᶦˢ ᵘˢᵉʳ
## Changelog
:cl:
add: Chemist, coroner, genetics, janitor, and virologist wintercoats are now available in the loadout.
add: Coroner's jumpskirt and jumpsuit are now available in the loadout.
/:cl:
