### PR TITLE
Removes some reagents from the safe scrubber overflow event

### DIFF
--- a/code/modules/events/scrubber_overflow.dm
+++ b/code/modules/events/scrubber_overflow.dm
@@ -36,7 +36,7 @@
 		/datum/reagent/blood,
 		// /datum/reagent/medicine/c2/multiver, // OCULIS EDIT
 		/datum/reagent/water/holywater,
-		/datum/reagent/consumable/ethanol,
+		// /datum/reagent/consumable/ethanol, // OCULIS EDIT
 		/datum/reagent/consumable/hot_coco,
 		/datum/reagent/consumable/yoghurt,
 		/datum/reagent/consumable/tinlux,

--- a/code/modules/events/scrubber_overflow.dm
+++ b/code/modules/events/scrubber_overflow.dm
@@ -26,15 +26,15 @@
 		/datum/reagent/carbon,
 		/datum/reagent/consumable/flour,
 		/datum/reagent/space_cleaner,
-		/datum/reagent/carpet/royal/blue,
-		/datum/reagent/carpet/orange,
+		// /datum/reagent/carpet/royal/blue, // OCULIS EDIT
+		// /datum/reagent/carpet/orange, // OCULIS EDIT
 		/datum/reagent/consumable/nutriment,
 		/datum/reagent/consumable/condensedcapsaicin,
 		/datum/reagent/drug/mushroomhallucinogen,
 		/datum/reagent/lube,
 		/datum/reagent/cryptobiolin,
 		/datum/reagent/blood,
-		/datum/reagent/medicine/c2/multiver,
+		// /datum/reagent/medicine/c2/multiver, // OCULIS EDIT
 		/datum/reagent/water/holywater,
 		/datum/reagent/consumable/ethanol,
 		/datum/reagent/consumable/hot_coco,
@@ -44,12 +44,12 @@
 		/datum/reagent/bluespace,
 		/datum/reagent/pax,
 		/datum/reagent/consumable/laughter,
-		/datum/reagent/concentrated_barbers_aid,
-		/datum/reagent/baldium,
+		// /datum/reagent/concentrated_barbers_aid, // OCULIS EDIT
+		// /datum/reagent/baldium, // OCULIS EDIT
 		/datum/reagent/colorful_reagent,
 		/datum/reagent/consumable/salt,
 		/datum/reagent/consumable/ethanol/beer,
-		/datum/reagent/hair_dye,
+		// /datum/reagent/hair_dye, // OCULIS EDIT
 		/datum/reagent/consumable/sugar,
 		/datum/reagent/glitter/random,
 		/datum/reagent/gravitum,


### PR DESCRIPTION

## About The Pull Request
Removes the following from the pool of "safer chems" for scrubber overflow events:
- Royal blue carpet
- Orange carpet
- Multiver
- Concentrated barber's aid
- Baldium
- Hair dye
- Ethanol
## Why it's Good for the Game
The carpets are removed because while they can be easily replaced with the correct tiles, they delete the decals, which cannot always easily be replaced without looking at the original map as a reference. This is even more punishing to players who make rooms with custom tiles and decals in-round.
Multiver and ethanol are removed because large doses of those chems are actually very lethal, which doesn't fit a safe event.
Concentrated barber's aid, baldium, and hair dye are removed because they mess with your character's appearance which sucks for a roleplay game. While they are fixable by going to the barber vending machine and using the items there or with a SAD, forcing characters with no barber experience to use barber equipment detracts from roleplay. The hair chems rarely add roleplay value unless someone happens to be playing a barber, which is a niche role. Finally, some players are very stressed by their character being modified against their will (see https://discord.com/channels/1460038464035618929/1486533262112198799/1487250369171161240). All in all, there's little reason to keep the hair chems and good reasons to get rid of them.
Screenshots of the discord conversation, taken 2026-03-27 8:24PM PT:
<img width="532" height="432" alt="image" src="https://github.com/user-attachments/assets/4746057e-0a48-4801-8552-0e5fdcd539b6" />
<img width="317" height="81" alt="image" src="https://github.com/user-attachments/assets/aa07aa65-7701-4c92-ad34-19781fe06026" />

## Proof of Testing
The event runs, no carpet. Lots of runtimes, but not in code I touched.
<img width="2560" height="1380" alt="image" src="https://github.com/user-attachments/assets/44addbaf-60a5-4de0-976a-65e35852a431" />
<img width="2560" height="1380" alt="image" src="https://github.com/user-attachments/assets/218b487e-0275-48bb-84b3-43afb1aea298" />
## Changelog
:cl:
del: Removed carpet, multiver, ethanol, and hair changing reagents from regular scrubber overflows.
/:cl:
