### PR TITLE
Adds prisoner IDs to Serenity

### DIFF
--- a/_maps/map_files/SerenityStation/SerenityStation.dmm
+++ b/_maps/map_files/SerenityStation/SerenityStation.dmm
@@ -65917,6 +65917,10 @@
 	pixel_y = 4
 	},
 /obj/effect/turf_decal/tile/neutral/fourcorners,
+/obj/item/storage/box/prisoner{
+	pixel_x = -15;
+	pixel_y = 0
+	},
 /turf/open/floor/iron,
 /area/station/security/execution/transfer)
 "tie" = (


### PR DESCRIPTION

## About The Pull Request
Adds prisoner IDs to the brig in Serenity Station.
## Why it's Good for the Game
They're missing, every other map has them, the permabrig isn't very usable without them.
## Proof of Testing
<img width="2560" height="1380" alt="image" src="https://github.com/user-attachments/assets/bd03e72b-02c8-45ae-8b62-c20561501f21" />

## Changelog
:cl:
add: Added prisoner IDs to Serenity Station.
/:cl:
