### PR TITLE
Mother russia arms the mob free pulse rifles, FOR EVERYONE!!

### DIFF
--- a/_maps/map_files/generic/CentCom_oculis.dmm
+++ b/_maps/map_files/generic/CentCom_oculis.dmm
@@ -20880,6 +20880,10 @@
 /obj/effect/mapping_helpers/airlock/access/all/admin/captain,
 /obj/structure/cable,
 /obj/machinery/door/airlock/centcom,
+/obj/machinery/door/poddoor/shutters{
+	id = "XCCFerry";
+	name = "XCC Ferry Hangar"
+	},
 /turf/open/floor/iron/large,
 /area/centcom/central_command_areas/hallway)
 "uuZ" = (

--- a/_maps/map_files/generic/CentCom_oculis.dmm
+++ b/_maps/map_files/generic/CentCom_oculis.dmm
@@ -5820,6 +5820,7 @@
 "cDQ" = (
 /obj/machinery/door/airlock/command,
 /obj/effect/mapping_helpers/airlock/access/all/admin/captain,
+/obj/machinery/door/poddoor/shutters/window/indestructible,
 /turf/open/floor/wood,
 /area/centcom/castor/sectorial_logistics_administrator)
 "cEn" = (
@@ -7012,6 +7013,7 @@
 	max_integrity = 450
 	},
 /obj/effect/mapping_helpers/airlock/access/all/admin/captain,
+/obj/machinery/door/poddoor/shutters/window/indestructible,
 /turf/open/floor/wood/wood_7{
 	initial_gas_mix = "o2=21.65;n2=80.7;TEMP=287.53"
 	},
@@ -7725,6 +7727,7 @@
 /area/centcom/interlink)
 "fiY" = (
 /obj/structure/fans/tiny/forcefield,
+/obj/machinery/door/poddoor/shutters/window/indestructible,
 /turf/open/floor/plating,
 /area/centcom/central_command_areas/ferry)
 "fjw" = (
@@ -11291,6 +11294,7 @@
 /obj/machinery/door/airlock/vault,
 /obj/effect/mapping_helpers/airlock/access/all/admin/captain,
 /obj/machinery/door/firedoor,
+/obj/machinery/door/poddoor/shutters/window/indestructible,
 /turf/open/floor/engine,
 /area/centcom/castor/sectorial_security_administrator)
 "jxl" = (
@@ -11412,6 +11416,7 @@
 	},
 /obj/effect/mapping_helpers/airlock/access/all/admin/captain,
 /obj/machinery/door/firedoor,
+/obj/machinery/door/poddoor/shutters/window/indestructible,
 /turf/open/floor/wood,
 /area/centcom/castor/sectorial_engineering_administrator)
 "jGp" = (
@@ -12038,6 +12043,7 @@
 	id_tag = "SPABackroom"
 	},
 /obj/effect/mapping_helpers/airlock/access/all/admin/captain,
+/obj/machinery/door/poddoor/shutters/window/indestructible,
 /turf/open/floor/wood/parquet,
 /area/centcom/castor/sectorial_personnel_administrator)
 "kyP" = (
@@ -16650,6 +16656,7 @@
 /obj/machinery/door/airlock/command,
 /obj/effect/mapping_helpers/airlock/access/all/admin/captain,
 /obj/machinery/door/firedoor,
+/obj/machinery/door/poddoor/shutters/window/indestructible,
 /turf/open/floor/wood/parquet,
 /area/centcom/castor/sectorial_engineering_administrator)
 "pIt" = (


### PR DESCRIPTION

## About The Pull Request

If in the future you want to add set piece gear go to its variables in strongdmm and adjust the "anchored" variable from 0 to 1, this will make it un-obtanium to the players except in the case of code writing exploits (un-insulated places to write things, the code guns from way back when that could execute commands etc) which to my knowledge doesnt exist, nothing else can un-anchor an object, if fallout thirteen players cannot figure out how to un-anchor items across five years of playing their servers, i dont think oculis players can.

## Why it's Good for the Game

No more free pulse rifles

## Proof of Testing

I dont need to test this shi thisll keep players out
(the area has noteleport, the walls surrounding the things are indestructible, players cannot get in through normal means)

## Changelog

fixes oversights

:cl:
fix: no more free pulse rifles and admin suits from centcom, sorry gang.
/:cl: