### PR TITLE
Oversized Ethereals may keep their biobattery

### DIFF
--- a/modular_nova/modules/customization/modules/mob/living/carbon/human/species.dm
+++ b/modular_nova/modules/customization/modules/mob/living/carbon/human/species.dm
@@ -46,6 +46,11 @@ GLOBAL_LIST_EMPTY(customizable_races)
 	if(old_stomach?.is_oversized) // don't override augments that are already oversized. Need to do this because augments get applied first, so quirks will overwrite them. TODO: Maybe the augments middleware should be renamed so it gets applied last.
 		return
 
+	// OCULIS EDIT ADDITION START
+	if(istype(old_stomach, /obj/item/organ/stomach/ethereal))	//If your oversized ethereal has a biobattery, keep it.
+		return
+	// OCULIS EDIT ADDITION END
+
 	var/obj/item/organ/stomach/oversized/new_stomach = new //YOU LOOK HUGE, THAT MUST MEAN YOU HAVE HUGE GUTS! RIP AND TEAR YOUR HUGE GUTS!
 	oversized_quirk.old_organs += list(old_stomach)
 


### PR DESCRIPTION

## About The Pull Request

Previously, Ethereals with the Oversized trait would automatically lose their biobattery.
This impacts Ethereals who need/want a biobattery, such as Ethereals with the Entombed trait.
Now you can be an Ethereal with the Oversized trait and have a biobattery.
## Why it's Good for the Game

No longer forces staff members to manually fix big fused ethereals every time one wants to play.
## Proof of Testing

<img width="464" height="396" alt="image" src="https://github.com/user-attachments/assets/159abfe4-2408-4799-b377-d4b0230f2b2b" />

## Changelog
:cl:
fix: Ethereals with the quirk Oversized no longer have their biobatteries replaced with huge guts.
/:cl:
