### PR TITLE
Marauder balance PR

### DIFF
--- a/_maps/nova/lazy_templates/midround_traitor.dmm
+++ b/_maps/nova/lazy_templates/midround_traitor.dmm
@@ -1935,6 +1935,7 @@
 /obj/item/food/rationpack{
 	pixel_y = -2
 	},
+/obj/item/uplink,
 /turf/open/floor/iron/dark/smooth_large,
 /area/misc/operative_barracks/dorm)
 "xU" = (
@@ -3147,6 +3148,25 @@
 "OZ" = (
 /obj/effect/turf_decal/siding/wood{
 	dir = 1
+	},
+/obj/effect/turf_decal/arrows/red{
+	dir = 4;
+	pixel_y = 8
+	},
+/obj/effect/turf_decal/arrows/red{
+	dir = 4;
+	pixel_y = 4
+	},
+/obj/effect/turf_decal/arrows/red{
+	dir = 4
+	},
+/obj/effect/turf_decal/arrows/red{
+	dir = 4;
+	pixel_y = -4
+	},
+/obj/effect/turf_decal/arrows/red{
+	dir = 4;
+	pixel_y = -8
 	},
 /turf/open/floor/carpet/grimey,
 /area/misc/operative_barracks/dorm)

--- a/_maps/nova/lazy_templates/midround_traitor.dmm
+++ b/_maps/nova/lazy_templates/midround_traitor.dmm
@@ -3149,25 +3149,6 @@
 /obj/effect/turf_decal/siding/wood{
 	dir = 1
 	},
-/obj/effect/turf_decal/arrows/red{
-	dir = 4;
-	pixel_y = 8
-	},
-/obj/effect/turf_decal/arrows/red{
-	dir = 4;
-	pixel_y = 4
-	},
-/obj/effect/turf_decal/arrows/red{
-	dir = 4
-	},
-/obj/effect/turf_decal/arrows/red{
-	dir = 4;
-	pixel_y = -4
-	},
-/obj/effect/turf_decal/arrows/red{
-	dir = 4;
-	pixel_y = -8
-	},
 /turf/open/floor/carpet/grimey,
 /area/misc/operative_barracks/dorm)
 "Pa" = (

--- a/modular_nova/modules/marauders/marauder_fluff.dm
+++ b/modular_nova/modules/marauders/marauder_fluff.dm
@@ -45,7 +45,7 @@
 	add_raw_text("The last cargo technician has packed up delivery, the gear is restocked and the shuttle refueled. It seems you are still asleep, so instead I'll just leave this note. \n\n\
 		I know the place is a mess, but it has everything you need for a mission in a sector like The Orion Spur. \n\
 		Scope out your options and determine a plan of action, take your time!! \n\n\
-		One more thing, the higher ups told everyone to stop wasting expensive equipment on missions with low paygrades. Id est don't bring a thirtythousand credit mech to steal a fivethousand credit jetpack. \n\n\
+		You have your uplink and vouchers. Use them sparingly. \n\n\
 		Oh, and give Clover another headpat for me.")
 	add_raw_text("<font face=\"[SIGNATURE_FONT]\">[pick(GLOB.first_names)]</font>, \n\
 		Rotation operative [rand(2,12)]")

--- a/modular_nova/modules/marauders/marauder_fluff.dm
+++ b/modular_nova/modules/marauders/marauder_fluff.dm
@@ -40,7 +40,7 @@
 		addressed_to = name
 	else
 		addressed_to = "[first_name(name)]"
-
+//oculis edit 4/3/2026
 	add_raw_text("[addressed_to],")
 	add_raw_text("The last cargo technician has packed up delivery, the gear is restocked and the shuttle refueled. It seems you are still asleep, so instead I'll just leave this note. \n\n\
 		I know the place is a mess, but it has everything you need for a mission in a sector like The Orion Spur. \n\
@@ -49,3 +49,4 @@
 		Oh, and give Clover another headpat for me.")
 	add_raw_text("<font face=\"[SIGNATURE_FONT]\">[pick(GLOB.first_names)]</font>, \n\
 		Rotation operative [rand(2,12)]")
+//end oculis edit

--- a/modular_nova/modules/marauders/marauder_fluff.dm
+++ b/modular_nova/modules/marauders/marauder_fluff.dm
@@ -49,4 +49,4 @@
 		Oh, and give Clover another headpat for me.")
 	add_raw_text("<font face=\"[SIGNATURE_FONT]\">[pick(GLOB.first_names)]</font>, \n\
 		Rotation operative [rand(2,12)]")
-//end oculis edit
+//end oculis  edit

--- a/modular_nova/modules/marauders/marauder_map.dm
+++ b/modular_nova/modules/marauders/marauder_map.dm
@@ -86,7 +86,9 @@ MAPPING_DIRECTIONAL_HELPERS(/obj/machinery/computer/security/telescreen/traitor_
 
 //area
 /area/shuttle/traitor
+	//oculis edit 4/3/2026
 	requires_power = FALSE
+	//end oculis edit
 	name = "\proper Razorfeather 8E short-range cruiser"
 	flags_1 = NONE
 

--- a/modular_nova/modules/marauders/marauder_map.dm
+++ b/modular_nova/modules/marauders/marauder_map.dm
@@ -86,7 +86,7 @@ MAPPING_DIRECTIONAL_HELPERS(/obj/machinery/computer/security/telescreen/traitor_
 
 //area
 /area/shuttle/traitor
-	requires_power = TRUE
+	requires_power = FALSE
 	name = "\proper Razorfeather 8E short-range cruiser"
 	flags_1 = NONE
 


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Semi-ided marauder balance PR.
Gives them a traitor uplink(because that is what they are, ghost roll traitors) with 35 tc, same as regular traitors.
They still keep their vouchers.
Also, their shuttle is now powerless so it doesn't require power. Yay

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why it's Good for the Game
Their balance is currently very busted. Currently you get:
1 primary weapon voucher
1 secondary weapon voucher
1 medical implant voucher
1 robotics voucher
1 general equipment voucher
And you can trade any of these vouchers for a medical implant voucher, secondary weapon voucher or general equipment voucher.
**This is not fair for the Marauder.**
Given that we are Oculis, not Nova, some more leeway is given for traitors and antags and whatnot.
As the original PR of marauder says: https://github.com/NovaSector/NovaSector/pull/5766
"In simple terms, its traitor for ghosts."
They should not be limited to just a few bits of traitor equipment.
They should be given freedom to experiment and tinker with all kinds of different traitor equipment.
Also, with the current voucher system, It's easy to mis-trade a voucher like a robotics voucher and end up not getting something crucial like a MODsuit, for example.
Marauders are like lone ops without the nuke now. They are ENFORCED by the rules to do their objectives and not go and murderbone everyone.
This makes it fairer for them since they are only ONE person(tbh they could just order reinforcements from their uplink but that would mean worse equipment, eh)

Their shuttle now doesn't require power, just like any other ghost role shuttle. When the shuttle moved it would also shift and move the APC into wonky locations and that would make it hard to charge it.

<!-- Please add a short description of why you think these changes would benefit the game and the roleplay atmosphere of the server. If you can't justify it in words, it might not be worth adding. -->

## Proof of Testing
I couldn't test it because I'm lonely and i couldn't force myself to be a marauder in my own server god damn
<img width="350" height="200" alt="image" src="https://github.com/user-attachments/assets/d9f6e141-eaa0-470e-94e3-dc73e6312707" />


<!-- Include any screenshots/videos/debugging steps of the code functioning successfully-->
<!-- To our mappers and spriters: Posting screenshots of content INSIDE EDITORS (aseprite, PDN, SDMM, ect) is NOT valid proof of testing. Please make sure that you COMPILE the game and provide PROOF you tested your edits. -->

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
balance: Marauder now gets a traitor uplink alongside his vouchers. Syndichads rejoice.
fix: Marauder's shuttle now doesn't require any power. Syndichads rejoice.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
