### PR TITLE
GUNCARGO-B-GONE.

### DIFF
--- a/modular_nova/master_files/code/modules/cargo/packs/companies/ballistics.dm
+++ b/modular_nova/master_files/code/modules/cargo/packs/companies/ballistics.dm
@@ -51,10 +51,11 @@
 	access_view = FALSE
 	express_lock = FALSE
 	order_flags = ORDER_COMPANY
-
+*/
 // Sol Fed Weapons
 /datum/supply_pack/companies/ballistics/sol_fed
-
+	cost = CARGO_CRATE_VALUE * 2
+/*
 /datum/supply_pack/companies/ballistics/sol_fed/sidearm
 	cost = CARGO_CRATE_VALUE * 2
 	access = FALSE
@@ -64,10 +65,12 @@
 
 /datum/supply_pack/companies/ballistics/sol_fed/sidearm/eland
 	contains = list(/obj/item/gun/ballistic/revolver/sol)
-
+*/
 /datum/supply_pack/companies/ballistics/sol_fed/sidearm/wespe
 	contains = list(/obj/item/gun/ballistic/automatic/pistol/sol)
-
+	access = ACCESS_WEAPONS
+	access_view = ACCESS_WEAPONS
+/*
 /datum/supply_pack/companies/ballistics/sol_fed/sidearm/type207
 	contains = list(/obj/item/gun/ballistic/automatic/pistol/type207)
 
@@ -141,13 +144,13 @@
 	contains = list(/obj/item/gun/ballistic/automatic/sol_grenade_launcher)
 	cost = CARGO_CRATE_VALUE * 23
 
-*/
+
 // HC Surplus
 
 /datum/supply_pack/companies/ballistics/hc_surplus
 	cost = CARGO_CRATE_VALUE * 3
 
-/*
+
 
 /datum/supply_pack/companies/ballistics/hc_surplus/shotgun_revolver
 	contains = list(/obj/item/gun/ballistic/revolver/shotgun_revolver)

--- a/modular_nova/master_files/code/modules/cargo/packs/companies/ballistics.dm
+++ b/modular_nova/master_files/code/modules/cargo/packs/companies/ballistics.dm
@@ -54,7 +54,7 @@
 */
 // Sol Fed Weapons
 /datum/supply_pack/companies/ballistics/sol_fed
-	cost = CARGO_CRATE_VALUE * 2
+	cost = CARGO_CRATE_VALUE * 2.8
 /*
 /datum/supply_pack/companies/ballistics/sol_fed/sidearm
 	cost = CARGO_CRATE_VALUE * 2

--- a/modular_nova/master_files/code/modules/cargo/packs/companies/ballistics.dm
+++ b/modular_nova/master_files/code/modules/cargo/packs/companies/ballistics.dm
@@ -6,6 +6,7 @@
 	order_flags = ORDER_GOODY
 	discountable = SUPPLY_PACK_STD_DISCOUNTABLE
 
+/* //OCULIS EDIT START - guncargo-b-gone
 // NT Weapons
 
 /datum/supply_pack/companies/ballistics/nt
@@ -140,10 +141,13 @@
 	contains = list(/obj/item/gun/ballistic/automatic/sol_grenade_launcher)
 	cost = CARGO_CRATE_VALUE * 23
 
+*/
 // HC Surplus
 
 /datum/supply_pack/companies/ballistics/hc_surplus
 	cost = CARGO_CRATE_VALUE * 3
+
+/*
 
 /datum/supply_pack/companies/ballistics/hc_surplus/shotgun_revolver
 	contains = list(/obj/item/gun/ballistic/revolver/shotgun_revolver)
@@ -179,6 +183,7 @@
 	contains = list(/obj/item/gun/ballistic/automatic/wylom)
 	cost = CARGO_CRATE_VALUE * 8
 
+*/ //OCULIS EDIT END
 // Donk
 
 /datum/supply_pack/companies/ballistics/donk

--- a/modular_nova/master_files/code/modules/cargo/packs/companies/ballistics.dm
+++ b/modular_nova/master_files/code/modules/cargo/packs/companies/ballistics.dm
@@ -6,7 +6,7 @@
 	order_flags = ORDER_GOODY
 	discountable = SUPPLY_PACK_STD_DISCOUNTABLE
 
- //OCULIS EDIT START - guncargo-b-gone
+//OCULIS EDIT START - guncargo-b-gone
 // NT Weapons
 
 /datum/supply_pack/companies/ballistics/nt

--- a/modular_nova/master_files/code/modules/cargo/packs/companies/ballistics.dm
+++ b/modular_nova/master_files/code/modules/cargo/packs/companies/ballistics.dm
@@ -6,7 +6,7 @@
 	order_flags = ORDER_GOODY
 	discountable = SUPPLY_PACK_STD_DISCOUNTABLE
 
-/* //OCULIS EDIT START - guncargo-b-gone
+ //OCULIS EDIT START - guncargo-b-gone
 // NT Weapons
 
 /datum/supply_pack/companies/ballistics/nt
@@ -17,8 +17,6 @@
 	desc = "The HoS took your gun and your badge? No problem! Just pay the absurd taxation fee and you too can be reunited with the lethal power of a .38!"
 	cost = CARGO_CRATE_VALUE * 2.5
 	auto_name = FALSE
-	access = FALSE
-	access_view = FALSE
 	express_lock = FALSE
 	order_flags = ORDER_COMPANY
 	contains = list(/obj/item/gun/ballistic/revolver/c38/detective)
@@ -28,15 +26,15 @@
 	desc = "Lost your beloved bunny to a demonic invasion? Clown broke in and stole your beloved gun? No worries! Get a new gun as long as you can pay the absurd fees."
 	cost = CARGO_CRATE_VALUE * 2
 	auto_name = FALSE
-	access = FALSE
-	access_view = FALSE
 	express_lock = FALSE
 	order_flags = ORDER_COMPANY
 	contains = list(/obj/item/gun/ballistic/shotgun/doublebarrel)
 
+/* OCULIS EDIT START autoshotgun... why?
 /datum/supply_pack/companies/ballistics/nt/shotgun_automatic
 	cost = CARGO_CRATE_VALUE * 5
 	contains = list(/obj/item/gun/ballistic/shotgun/automatic/combat)
+*/ //OCULIS EDIT END
 
 /datum/supply_pack/companies/ballistics/nt/c38_super_kit
 	name = "NT/E \"Laevateinn\" Revolver Conversion Kit"
@@ -47,30 +45,25 @@
 		/obj/item/crafting_conversion_kit/c38_speedloader_plus,
 	)
 	auto_name = FALSE
-	access = FALSE
-	access_view = FALSE
+
+
 	express_lock = FALSE
 	order_flags = ORDER_COMPANY
-*/
+
 // Sol Fed Weapons
 /datum/supply_pack/companies/ballistics/sol_fed
-	cost = CARGO_CRATE_VALUE * 2.8
-/*
+
 /datum/supply_pack/companies/ballistics/sol_fed/sidearm
-	cost = CARGO_CRATE_VALUE * 2
-	access = FALSE
-	access_view = FALSE
+	cost = CARGO_CRATE_VALUE * 2.8
 	express_lock = FALSE
 	order_flags = ORDER_COMPANY
 
 /datum/supply_pack/companies/ballistics/sol_fed/sidearm/eland
 	contains = list(/obj/item/gun/ballistic/revolver/sol)
-*/
+
 /datum/supply_pack/companies/ballistics/sol_fed/sidearm/wespe
 	contains = list(/obj/item/gun/ballistic/automatic/pistol/sol)
-	access = ACCESS_WEAPONS
-	access_view = ACCESS_WEAPONS
-/*
+
 /datum/supply_pack/companies/ballistics/sol_fed/sidearm/type207
 	contains = list(/obj/item/gun/ballistic/automatic/pistol/type207)
 
@@ -84,6 +77,8 @@
 
 /datum/supply_pack/companies/ballistics/sol_fed/longarm
 	cost = CARGO_CRATE_VALUE * 3
+	access = ACCESS_ARMORY	//OCULIS EDIT
+	access_view = ACCESS_ARMORY	//OCULIS EDIT
 
 /datum/supply_pack/companies/ballistics/sol_fed/longarm/renoster_super_kit
 	name = "Archon Systems \"KOLBEN/NACHTREIHER\" M64 Shotgun Conversion Kit"
@@ -91,8 +86,6 @@
 	cost = CARGO_CRATE_VALUE * 3 // 600 cr at time of writing, 1200 cr total
 	contains = list(/obj/item/crafting_conversion_kit/riot_sol_super)
 	auto_name = FALSE
-	access = FALSE
-	access_view = FALSE
 	express_lock = FALSE
 
 /datum/supply_pack/companies/ballistics/sol_fed/longarm/doublebarrel_super_kit
@@ -101,8 +94,6 @@
 	cost = CARGO_CRATE_VALUE * 3 // 600 cr at time of writing, 1000 cr total
 	contains = list(/obj/item/crafting_conversion_kit/doublebarrel_super)
 	auto_name = FALSE
-	access = FALSE
-	access_view = FALSE
 	express_lock = FALSE
 
 /datum/supply_pack/companies/ballistics/sol_fed/longarm/renoster
@@ -140,10 +131,11 @@
 	cost = CARGO_CRATE_VALUE * 11.5
 */ //Commented out due to a severe lack of balance regarding it.
 
+/*	OCULIS EDIT START
 /datum/supply_pack/companies/ballistics/sol_fed/longarm/kiboko
 	contains = list(/obj/item/gun/ballistic/automatic/sol_grenade_launcher)
 	cost = CARGO_CRATE_VALUE * 23
-
+*/ //OCULIS EDIT END crew should not be ordering a grenade launcher
 
 // HC Surplus
 
@@ -151,37 +143,43 @@
 	cost = CARGO_CRATE_VALUE * 3
 
 
-
+/* OCULIS EDIT START
 /datum/supply_pack/companies/ballistics/hc_surplus/shotgun_revolver
 	contains = list(/obj/item/gun/ballistic/revolver/shotgun_revolver)
-	access = FALSE
-	access_view = FALSE
 	express_lock = FALSE
 	order_flags = ORDER_COMPANY
+*/ //OCULIS EDIT END HAND HELD PULSE PISTOL!
 
 /datum/supply_pack/companies/ballistics/hc_surplus/zashch
 	contains = list(/obj/item/gun/ballistic/automatic/pistol/zashch)
-	access = FALSE
-	access_view = FALSE
 	express_lock = FALSE
 	order_flags = ORDER_COMPANY
 
 /datum/supply_pack/companies/ballistics/hc_surplus/miecz
 	contains = list(/obj/item/gun/ballistic/automatic/miecz)
 	cost = CARGO_CRATE_VALUE * 5
+	access = ACCESS_ARMORY	//OCULIS EDIT
+	access_view = ACCESS_ARMORY	//OCULIS EDIT
 
 /datum/supply_pack/companies/ballistics/hc_surplus/napad
 	contains = list(/obj/item/gun/ballistic/automatic/napad)
 	cost = CARGO_CRATE_VALUE * 6
+	access = ACCESS_ARMORY	//OCULIS EDIT
+	access_view = ACCESS_ARMORY	//OCULIS EDIT
 
 /datum/supply_pack/companies/ballistics/hc_surplus/sakhno_rifle
 	contains = list(/obj/item/gun/ballistic/rifle/boltaction)
 	cost = CARGO_CRATE_VALUE * 6
+	access = ACCESS_ARMORY	//OCULIS EDIT
+	access_view = ACCESS_ARMORY	//OCULIS EDIT
 
 /datum/supply_pack/companies/ballistics/hc_surplus/lanca
 	contains = list(/obj/item/gun/ballistic/automatic/lanca)
 	cost = CARGO_CRATE_VALUE * 7
+	access = ACCESS_ARMORY	//OCULIS EDIT
+	access_view = ACCESS_ARMORY	//OCULIS EDIT
 
+/* OCULIS EDIT START
 /datum/supply_pack/companies/ballistics/hc_surplus/anti_materiel_rifle
 	contains = list(/obj/item/gun/ballistic/automatic/wylom)
 	cost = CARGO_CRATE_VALUE * 8
@@ -190,8 +188,8 @@
 // Donk
 
 /datum/supply_pack/companies/ballistics/donk
-	access = FALSE
-	access_view = FALSE
+
+
 	express_lock = FALSE
 	order_flags = ORDER_COMPANY
 	discountable = SUPPLY_PACK_NOT_DISCOUNTABLE
@@ -227,3 +225,5 @@
 /datum/supply_pack/companies/ballistics/blacksteel/longbow
 	contains = list(/obj/item/gun/ballistic/bow/longbow)
 	cost = CARGO_CRATE_VALUE * 1.5
+	access = FALSE	//OCULIS EDIT
+	access_view = FALSE	//OCULIS EDIT

--- a/modular_nova/master_files/code/modules/cargo/packs/companies/energy.dm
+++ b/modular_nova/master_files/code/modules/cargo/packs/companies/energy.dm
@@ -1,3 +1,4 @@
+/* OCULIS EDIT START - Gun cargo total death mark 1
 /datum/supply_pack/companies/energy
 	group = "★ Energy Weapons"
 	access = ACCESS_WEAPONS
@@ -124,3 +125,4 @@
 /datum/supply_pack/companies/energy/hc_surplus/zaibas_a
 	contains = list(/obj/item/gun/ballistic/rifle/pulse_sniper)
 	cost = CARGO_CRATE_VALUE * 7
+*/ // OCULIS EDIT END

--- a/modular_nova/master_files/code/modules/cargo/packs/companies/energy.dm
+++ b/modular_nova/master_files/code/modules/cargo/packs/companies/energy.dm
@@ -1,4 +1,3 @@
-/* OCULIS EDIT START - Gun cargo total death mark 1
 /datum/supply_pack/companies/energy
 	group = "★ Energy Weapons"
 	access = ACCESS_WEAPONS
@@ -12,8 +11,6 @@
 
 /datum/supply_pack/companies/energy/microstar/basic_energy_weapons
 	cost = CARGO_CRATE_VALUE * 1.25
-	access = FALSE
-	access_view = FALSE
 	express_lock = FALSE
 	order_flags = ORDER_COMPANY
 
@@ -27,8 +24,8 @@
 /datum/supply_pack/companies/energy/microstar/basic_energy_weapons/disabler_smg
 	contains = list(/obj/item/gun/energy/disabler/smg)
 	cost = CARGO_CRATE_VALUE * 1.75
-	access = ACCESS_WEAPONS
-	access_view = ACCESS_WEAPONS
+	access = ACCESS_ARMORY	//OCULIS EDIT
+	access_view = ACCESS_ARMORY	//OCULIS EDIT
 	express_lock = TRUE
 	order_flags = ORDER_GOODY
 
@@ -43,34 +40,34 @@
 	cost = CARGO_CRATE_VALUE * 3
 
 /datum/supply_pack/companies/energy/microstar/basic_energy_long_weapons
+	access = ACCESS_ARMORY	//OCULIS EDIT
+	access_view = ACCESS_ARMORY	//OCULIS EDIT
 
 /datum/supply_pack/companies/energy/microstar/basic_energy_long_weapons/laser
 	contains = list(/obj/item/gun/energy/laser)
 	cost = CARGO_CRATE_VALUE * 1.25
-	access = FALSE
-	access_view = FALSE
 	express_lock = FALSE
 	order_flags = ORDER_COMPANY
 
 /datum/supply_pack/companies/energy/microstar/basic_energy_long_weapons/laser/soul
 	contains = list(/obj/item/gun/energy/laser/soul)
 
+
 /datum/supply_pack/companies/energy/microstar/basic_energy_long_weapons/laser_carbine
 	contains = list(/obj/item/gun/energy/laser/carbine)
 	cost = CARGO_CRATE_VALUE * 1.75
-
+/* OCULIS EDIT START
 /datum/supply_pack/companies/energy/microstar/basic_energy_long_weapons/laser_assault
 	contains = list(/obj/item/gun/energy/laser/assault)
 	cost = CARGO_CRATE_VALUE * 4
-
+*/ //OCULIS EDIT END
 /datum/supply_pack/companies/energy/microstar/basic_energy_long_weapons/egun
 	contains = list(/obj/item/gun/energy/e_gun)
 	cost = CARGO_CRATE_VALUE * 2
-	access = FALSE
-	access_view = FALSE
 	express_lock = FALSE
 	order_flags = ORDER_COMPANY
 
+/* OCULIS EDIT START
 /datum/supply_pack/companies/energy/microstar/basic_energy_long_weapons/mod_laser_small
 	contains = list(/obj/item/gun/energy/modular_laser_rifle/carbine)
 	cost = CARGO_CRATE_VALUE * 2.5
@@ -83,11 +80,17 @@
 	contains = list(/obj/item/gun/energy/modular_laser_rifle)
 	cost = CARGO_CRATE_VALUE * 4
 
+*/ // OCULIS EDIT END
+
 /datum/supply_pack/companies/energy/microstar/experimental_energy
 	cost = CARGO_CRATE_VALUE * 3
 
+
 /datum/supply_pack/companies/energy/microstar/experimental_energy/ion_carbine
 	contains = list(/obj/item/gun/energy/ionrifle/carbine)
+	access = ACCESS_ARMORY	//OCULIS EDIT
+	access_view = ACCESS_ARMORY	//OCULIS EDIT
+	//antiarmor weapon for the crew? why the **** not!
 
 // HC Weapons
 /datum/supply_pack/companies/energy/hc_surplus
@@ -97,16 +100,12 @@
 
 /datum/supply_pack/companies/energy/hc_surplus/plasma_marksman
 	contains = list(/obj/item/gun/ballistic/automatic/pistol/plasma_marksman)
-	access = FALSE
-	access_view = FALSE
 	express_lock = FALSE
 	order_flags = ORDER_COMPANY
 
 /datum/supply_pack/companies/energy/hc_surplus/crank_taser
 	contains = list(/obj/item/gun/energy/taser/crank)
 	cost = CARGO_CRATE_VALUE * 2
-	access = FALSE
-	access_view = FALSE
 	express_lock = FALSE
 	order_flags = ORDER_COMPANY
 
@@ -121,8 +120,11 @@
 /datum/supply_pack/companies/energy/hc_surplus/zaibas
 	contains = list(/obj/item/gun/ballistic/automatic/pulse_rifle)
 	cost = CARGO_CRATE_VALUE * 6
+	access = ACCESS_ARMORY	//OCULIS EDIT
+	access_view = ACCESS_ARMORY	//OCULIS EDIT
 
 /datum/supply_pack/companies/energy/hc_surplus/zaibas_a
 	contains = list(/obj/item/gun/ballistic/rifle/pulse_sniper)
 	cost = CARGO_CRATE_VALUE * 7
-*/ // OCULIS EDIT END
+	access = ACCESS_ARMORY	//OCULIS EDIT
+	access_view = ACCESS_ARMORY	//OCULIS EDIT

--- a/modular_oculis/master_files/code/modules/cargo/packs/companies/ballistics.dm
+++ b/modular_oculis/master_files/code/modules/cargo/packs/companies/ballistics.dm
@@ -1,8 +1,6 @@
-/* why man? you were supposed to be the chosen one
 /datum/supply_pack/companies/ballistics/hc_surplus/m1911
 	contains = list(/obj/item/gun/ballistic/automatic/pistol/m1911)
 	access = ACCESS_WEAPONS
 	access_view = ACCESS_WEAPONS
 	express_lock = FALSE
 	order_flags = ORDER_COMPANY
-*/

--- a/modular_oculis/master_files/code/modules/cargo/packs/companies/ballistics.dm
+++ b/modular_oculis/master_files/code/modules/cargo/packs/companies/ballistics.dm
@@ -1,6 +1,6 @@
 /datum/supply_pack/companies/ballistics/hc_surplus/m1911
 	contains = list(/obj/item/gun/ballistic/automatic/pistol/m1911)
-	access = FALSE
-	access_view = FALSE
+	access = ACCESS_WEAPONS
+	access_view = ACCESS_WEAPONS
 	express_lock = FALSE
 	order_flags = ORDER_COMPANY

--- a/modular_oculis/master_files/code/modules/cargo/packs/companies/ballistics.dm
+++ b/modular_oculis/master_files/code/modules/cargo/packs/companies/ballistics.dm
@@ -1,6 +1,8 @@
+/* why man? you were supposed to be the chosen one
 /datum/supply_pack/companies/ballistics/hc_surplus/m1911
 	contains = list(/obj/item/gun/ballistic/automatic/pistol/m1911)
 	access = ACCESS_WEAPONS
 	access_view = ACCESS_WEAPONS
 	express_lock = FALSE
 	order_flags = ORDER_COMPANY
+*/


### PR DESCRIPTION

## About The Pull Request
this permit locks most weapons orderable from the companies/balistics.dm and companies/energy.dm with the exclusion of weapons that excessively break the mold of weapons, the laser assault rifle, modular rifles, the grenade launcher, and the automatic shotgun + shotgun pistol. longarms are locked behind armory access in preperation for discrete weapons permits. 
## Why it's Good for the Game
every crewmember could rapidly get hilariously powerful guns for cheap without even a weapons permit
you need a permit now. 
Disabled cargo packs containing weapons people thought were overpowered along with the stand out shotguns
## Proof of Testing
I tested, that's how I found the m1911
## Changelog
:cl:
bal: made most nova cargo pack overrides relating to guns be permit locked
del: disabled the most egregious weapons available to the crew
/:cl:
