### PR TITLE
Permit locks all Nova Sector firearms in cargo

### DIFF
--- a/modular_nova/master_files/code/modules/cargo/packs/companies/ballistics.dm
+++ b/modular_nova/master_files/code/modules/cargo/packs/companies/ballistics.dm
@@ -16,9 +16,9 @@
 	desc = "The HoS took your gun and your badge? No problem! Just pay the absurd taxation fee and you too can be reunited with the lethal power of a .38!"
 	cost = CARGO_CRATE_VALUE * 2.5
 	auto_name = FALSE
-	access = FALSE
-	access_view = FALSE
-	express_lock = FALSE
+	// access = FALSE // OCULIS EDIT
+	// access_view = FALSE // OCULIS EDIT
+	// express_lock = FALSE // OCULIS EDIT
 	order_flags = ORDER_COMPANY
 	contains = list(/obj/item/gun/ballistic/revolver/c38/detective)
 
@@ -27,9 +27,9 @@
 	desc = "Lost your beloved bunny to a demonic invasion? Clown broke in and stole your beloved gun? No worries! Get a new gun as long as you can pay the absurd fees."
 	cost = CARGO_CRATE_VALUE * 2
 	auto_name = FALSE
-	access = FALSE
-	access_view = FALSE
-	express_lock = FALSE
+	// access = FALSE // OCULIS EDIT
+	// access_view = FALSE // OCULIS EDIT
+	// express_lock = FALSE // OCULIS EDIT
 	order_flags = ORDER_COMPANY
 	contains = list(/obj/item/gun/ballistic/shotgun/doublebarrel)
 
@@ -46,9 +46,9 @@
 		/obj/item/crafting_conversion_kit/c38_speedloader_plus,
 	)
 	auto_name = FALSE
-	access = FALSE
-	access_view = FALSE
-	express_lock = FALSE
+	// access = FALSE // OCULIS EDIT
+	// access_view = FALSE // OCULIS EDIT
+	// express_lock = FALSE // OCULIS EDIT
 	order_flags = ORDER_COMPANY
 
 // Sol Fed Weapons
@@ -56,9 +56,9 @@
 
 /datum/supply_pack/companies/ballistics/sol_fed/sidearm
 	cost = CARGO_CRATE_VALUE * 2
-	access = FALSE
-	access_view = FALSE
-	express_lock = FALSE
+	// access = FALSE // OCULIS EDIT
+	// access_view = FALSE // OCULIS EDIT
+	// express_lock = FALSE // OCULIS EDIT
 	order_flags = ORDER_COMPANY
 
 /datum/supply_pack/companies/ballistics/sol_fed/sidearm/eland
@@ -87,9 +87,9 @@
 	cost = CARGO_CRATE_VALUE * 3 // 600 cr at time of writing, 1200 cr total
 	contains = list(/obj/item/crafting_conversion_kit/riot_sol_super)
 	auto_name = FALSE
-	access = FALSE
-	access_view = FALSE
-	express_lock = FALSE
+	// access = FALSE // OCULIS EDIT
+	// access_view = FALSE // OCULIS EDIT
+	// express_lock = FALSE // OCULIS EDIT
 
 /datum/supply_pack/companies/ballistics/sol_fed/longarm/doublebarrel_super_kit
 	name = "Archon Systems \"LAMMERGEIER\" Double-Barrel Shotgun Conversion Kit"
@@ -97,9 +97,9 @@
 	cost = CARGO_CRATE_VALUE * 3 // 600 cr at time of writing, 1000 cr total
 	contains = list(/obj/item/crafting_conversion_kit/doublebarrel_super)
 	auto_name = FALSE
-	access = FALSE
-	access_view = FALSE
-	express_lock = FALSE
+	// access = FALSE // OCULIS EDIT
+	// access_view = FALSE // OCULIS EDIT
+	// express_lock = FALSE // OCULIS EDIT
 
 /datum/supply_pack/companies/ballistics/sol_fed/longarm/renoster
 	contains = list(/obj/item/gun/ballistic/shotgun/riot/sol)
@@ -147,16 +147,16 @@
 
 /datum/supply_pack/companies/ballistics/hc_surplus/shotgun_revolver
 	contains = list(/obj/item/gun/ballistic/revolver/shotgun_revolver)
-	access = FALSE
-	access_view = FALSE
-	express_lock = FALSE
+	// access = FALSE // OCULIS EDIT
+	// access_view = FALSE // OCULIS EDIT
+	// express_lock = FALSE // OCULIS EDIT
 	order_flags = ORDER_COMPANY
 
 /datum/supply_pack/companies/ballistics/hc_surplus/zashch
 	contains = list(/obj/item/gun/ballistic/automatic/pistol/zashch)
-	access = FALSE
-	access_view = FALSE
-	express_lock = FALSE
+	// access = FALSE // OCULIS EDIT
+	// access_view = FALSE // OCULIS EDIT
+	// express_lock = FALSE // OCULIS EDIT
 	order_flags = ORDER_COMPANY
 
 /datum/supply_pack/companies/ballistics/hc_surplus/miecz

--- a/modular_nova/master_files/code/modules/cargo/packs/companies/ballistics.dm
+++ b/modular_nova/master_files/code/modules/cargo/packs/companies/ballistics.dm
@@ -219,3 +219,6 @@
 /datum/supply_pack/companies/ballistics/blacksteel/longbow
 	contains = list(/obj/item/gun/ballistic/bow/longbow)
 	cost = CARGO_CRATE_VALUE * 1.5
+	access = FALSE
+	access_view = FALSE
+	express_lock = FALSE

--- a/modular_nova/master_files/code/modules/cargo/packs/companies/energy.dm
+++ b/modular_nova/master_files/code/modules/cargo/packs/companies/energy.dm
@@ -11,9 +11,9 @@
 
 /datum/supply_pack/companies/energy/microstar/basic_energy_weapons
 	cost = CARGO_CRATE_VALUE * 1.25
-	access = FALSE
-	access_view = FALSE
-	express_lock = FALSE
+	// access = FALSE // OCULIS EDIT
+	// access_view = FALSE // OCULIS EDIT
+	// express_lock = FALSE // OCULIS EDIT
 	order_flags = ORDER_COMPANY
 
 /datum/supply_pack/companies/energy/microstar/basic_energy_weapons/disabler
@@ -46,9 +46,9 @@
 /datum/supply_pack/companies/energy/microstar/basic_energy_long_weapons/laser
 	contains = list(/obj/item/gun/energy/laser)
 	cost = CARGO_CRATE_VALUE * 1.25
-	access = FALSE
-	access_view = FALSE
-	express_lock = FALSE
+	// access = FALSE // OCULIS EDIT
+	// access_view = FALSE // OCULIS EDIT
+	// express_lock = FALSE // OCULIS EDIT
 	order_flags = ORDER_COMPANY
 
 /datum/supply_pack/companies/energy/microstar/basic_energy_long_weapons/laser/soul
@@ -65,17 +65,17 @@
 /datum/supply_pack/companies/energy/microstar/basic_energy_long_weapons/egun
 	contains = list(/obj/item/gun/energy/e_gun)
 	cost = CARGO_CRATE_VALUE * 2
-	access = FALSE
-	access_view = FALSE
-	express_lock = FALSE
+	// access = FALSE // OCULIS EDIT
+	// access_view = FALSE // OCULIS EDIT
+	// express_lock = FALSE // OCULIS EDIT
 	order_flags = ORDER_COMPANY
 
 /datum/supply_pack/companies/energy/microstar/basic_energy_long_weapons/mod_laser_small
 	contains = list(/obj/item/gun/energy/modular_laser_rifle/carbine)
 	cost = CARGO_CRATE_VALUE * 2.5
-	access = FALSE
-	access_view = FALSE
-	express_lock = FALSE
+	// access = FALSE // OCULIS EDIT
+	// access_view = FALSE // OCULIS EDIT
+	// express_lock = FALSE // OCULIS EDIT
 	order_flags = ORDER_COMPANY
 
 /datum/supply_pack/companies/energy/microstar/basic_energy_long_weapons/mod_laser_large
@@ -96,25 +96,25 @@
 
 /datum/supply_pack/companies/energy/hc_surplus/plasma_marksman
 	contains = list(/obj/item/gun/ballistic/automatic/pistol/plasma_marksman)
-	access = FALSE
-	access_view = FALSE
-	express_lock = FALSE
+	// access = FALSE // OCULIS EDIT
+	// access_view = FALSE // OCULIS EDIT
+	// express_lock = FALSE // OCULIS EDIT
 	order_flags = ORDER_COMPANY
 
 /datum/supply_pack/companies/energy/hc_surplus/crank_taser
 	contains = list(/obj/item/gun/energy/taser/crank)
 	cost = CARGO_CRATE_VALUE * 2
-	access = FALSE
-	access_view = FALSE
-	express_lock = FALSE
+	// access = FALSE // OCULIS EDIT
+	// access_view = FALSE // OCULIS EDIT
+	// express_lock = FALSE // OCULIS EDIT
 	order_flags = ORDER_COMPANY
 
 /datum/supply_pack/companies/energy/hc_surplus/stun_gun //Not a gun but it's only fair to place similar items close to each other
 	contains = list(/obj/item/melee/baton/security/stun_gun/loaded)
 	cost = CARGO_CRATE_VALUE * 1.5 //Similarly live action roleplay'iy stun baton lite
-	access = FALSE
-	access_view = FALSE
-	express_lock = FALSE
+	// access = FALSE // OCULIS EDIT
+	// access_view = FALSE // OCULIS EDIT
+	// express_lock = FALSE // OCULIS EDIT
 	order_flags = ORDER_COMPANY
 
 /datum/supply_pack/companies/energy/hc_surplus/zaibas

--- a/modular_nova/master_files/code/modules/cargo/packs/companies/energy.dm
+++ b/modular_nova/master_files/code/modules/cargo/packs/companies/energy.dm
@@ -112,9 +112,9 @@
 /datum/supply_pack/companies/energy/hc_surplus/stun_gun //Not a gun but it's only fair to place similar items close to each other
 	contains = list(/obj/item/melee/baton/security/stun_gun/loaded)
 	cost = CARGO_CRATE_VALUE * 1.5 //Similarly live action roleplay'iy stun baton lite
-	// access = FALSE // OCULIS EDIT
-	// access_view = FALSE // OCULIS EDIT
-	// express_lock = FALSE // OCULIS EDIT
+	access = FALSE
+	access_view = FALSE
+	express_lock = FALSE
 	order_flags = ORDER_COMPANY
 
 /datum/supply_pack/companies/energy/hc_surplus/zaibas

--- a/modular_oculis/master_files/code/modules/cargo/packs/companies/ballistics.dm
+++ b/modular_oculis/master_files/code/modules/cargo/packs/companies/ballistics.dm
@@ -1,6 +1,3 @@
 /datum/supply_pack/companies/ballistics/hc_surplus/m1911
 	contains = list(/obj/item/gun/ballistic/automatic/pistol/m1911)
-	access = FALSE
-	access_view = FALSE
-	express_lock = FALSE
 	order_flags = ORDER_COMPANY


### PR DESCRIPTION

## About The Pull Request
Locks all Nova Sector firearms, ballistic and energy, to requiring a weapons permit for purchase from cargo. They are also excluded from express consoles. Standouts are the donk guns which are toys, the longbow which is not a firearm, and the stun gun which is a melee stunning tool and not a firearm.
## Why it's Good for the Game
Pretty much everyone agrees that crew should not be able to purchase firearms without a permit, especially longarms. While a more comprehensive permit system could be made, the server could use a simple fix in the meantime. The firearms have also been excluded from express consoles so that they cannot be covertly ordered by crew without going through cargo.
## Proof of Testing
<img width="2552" height="1378" alt="image" src="https://github.com/user-attachments/assets/85b3b19a-3065-4d48-9647-d09d92f6b301" />
<img width="2558" height="1458" alt="image" src="https://github.com/user-attachments/assets/4f2e8484-99a7-4eab-adf9-b20de6668acc" />
<img width="2558" height="1377" alt="image" src="https://github.com/user-attachments/assets/a9e22218-f33b-419f-87a1-d519865dee65" />
<img width="2558" height="1375" alt="image" src="https://github.com/user-attachments/assets/18ffee91-b099-4f3d-a67d-9ad459cf24e0" />

The express console change doesn't work because express consoles actually are bugged and don't lock out packs that should be locked. Express consoles don't pass that they're express to get_packs_data in orderconsole.dm, so they don't get locked out.
## Changelog
:cl:
balance: Cargo guns now require weapon permits to purchase.
balance: Cargo guns cannot be purchased from express consoles anymore, assuming express consoles check that correctly.
/:cl:
