### PR TITLE
Adds a Config Flag for Enabling NAD Lone Op Spawns

### DIFF
--- a/code/modules/antagonists/nukeop/equipment/nuclear_authentication_disk.dm
+++ b/code/modules/antagonists/nukeop/equipment/nuclear_authentication_disk.dm
@@ -23,7 +23,12 @@
 
 	if(!fake)
 		AddComponent(/datum/component/stationloving, !fake)
-		AddComponent(/datum/component/keep_me_secure, CALLBACK(src, PROC_REF(secured_process)), CALLBACK(src, PROC_REF(unsecured_process)), 10)
+		//OCULIS EDIT CHANGE START - NAD_LONE_OP_CONFIG
+		if(CONFIG_GET(flag/nad_can_spawn_lone_op))
+			AddComponent(/datum/component/keep_me_secure, CALLBACK(src, PROC_REF(secured_process)), CALLBACK(src, PROC_REF(unsecured_process)), 10)
+		else
+			AddComponent(/datum/component/keep_me_secure)
+		//OCULIS EDIT CHANGE END
 		SSpoints_of_interest.make_point_of_interest(src)
 	else
 		// Ensure fake disks still have examine text, but dont actually do anything

--- a/config/oculis/config.txt
+++ b/config/oculis/config.txt
@@ -1,2 +1,5 @@
 # Occasoinally log the output of memory debug to this rounds profiler folder.
 #AUTO_MEMORY_STATS
+
+## Uncomment to enable the chance of a Lone Operative spawning if the Nuclear Authentication Disk is left unmoved for too long
+#NAD_CAN_SPAWN_LONE_OP

--- a/modular_oculis/master_files/code/controllers/configuration/entries/game_options.dm
+++ b/modular_oculis/master_files/code/controllers/configuration/entries/game_options.dm
@@ -1,0 +1,1 @@
+/datum/config_entry/flag/nad_can_spawn_lone_op

--- a/tgstation.dme
+++ b/tgstation.dme
@@ -9893,6 +9893,7 @@
 #include "modular_nova\modules\xenoarchartifacts\obj\particle_battery.dm"
 #include "modular_nova\modules\xenoarchartifacts\obj\wave_scanner.dm"
 #include "modular_oculis\master_files\code\__HELPERS\files.dm"
+#include "modular_oculis\master_files\code\controllers\configuration\entries\game_options.dm"
 #include "modular_oculis\master_files\code\controllers\subsystem\persistence\_persistence.dm"
 #include "modular_oculis\master_files\code\datums\http.dm"
 #include "modular_oculis\master_files\code\game\atoms_movable.dm"


### PR DESCRIPTION

## About The Pull Request

Adds a config flag which, when uncommented, enables the possibility of an unmoved NAD spawning in a lone operative.
## Why it's Good for the Game

Gives server operators more control over the intended game experience.
## Proof of Testing

<img width="156" height="22" alt="ProcessingDebug" src="https://github.com/user-attachments/assets/44676105-6df5-4097-9945-67f5d02dcc8f" />

## Changelog
:cl:
code: NAD lone op spawn is able to be toggled using a config flag which defaults to disabled.
/:cl:
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones.
