### PR TITLE
Fixes Emote Cooldowns

### DIFF
--- a/modular_nova/modules/emotes/code/emotes.dm
+++ b/modular_nova/modules/emotes/code/emotes.dm
@@ -5,7 +5,7 @@
 	var/nextsoundemote = 1 //Time at which the next emote can be played
 
 /datum/emote
-	cooldown = EMOTE_DELAY
+	// cooldown = EMOTE_DELAY // OCULIS EDIT REMOVAL
 	var/muzzle_ignore = FALSE
 
 //Disables the custom emote blacklist from TG that normally applies to slimes.


### PR DESCRIPTION

## About The Pull Request
For some reason nova made all emotes have a delay of 2 seconds, increased from TG's 0.8 seconds delay. This sets it back to TG's.

## Why it's Good for the Game
Fixes your emotes being eaten due to an obnoxiously long delay.

## Proof of Testing
## Changelog
:cl:
fix: Fixed emote cooldown being 2 seconds. Lowered to 0.8, same as TG.
/:cl:
