### PR TITLE
Reduces Dive Anchor Fuel Cost

### DIFF
--- a/modular_iris/modules/dive_anchor/code/impure_telecrystal.dm
+++ b/modular_iris/modules/dive_anchor/code/impure_telecrystal.dm
@@ -13,6 +13,6 @@
 /datum/supply_pack/misc/impure_telecrystal
 	name = "Impure Telecrystal"
 	desc = "Fuel for mobile dive anchors."
-	cost = CARGO_CRATE_VALUE * 25
+	cost = CARGO_CRATE_VALUE * 5
 	contains = list(/obj/item/stack/impure_telecrystal)
 	crate_name = "dive anchor fuel crate"


### PR DESCRIPTION

## About The Pull Request

Significantly reduces the cost of dive anchor fuel crystals, taking them from 5000cr each to 1000cr each.
## Why it's Good for the Game

I think I vastly overpriced these when I added dive anchors and I'm hoping that a lowered cost will lead to those being used more.
## Proof of Testing
## Changelog
:cl:
balance: The "impure telecrystals" used to fuel dive anchors have been reduced in cost from 5000cr each to 1000cr each.
/:cl:
