### PR TITLE
[TM ONLY PLEASE] Height Prefs Hotfix

### DIFF
--- a/code/datums/dna/blocks/dna_identity_block.dm
+++ b/code/datums/dna/blocks/dna_identity_block.dm
@@ -138,11 +138,12 @@
 		HUMAN_HEIGHT_MEDIUM,
 		HUMAN_HEIGHT_TALL,
 		HUMAN_HEIGHT_TALLER,
+		HUMAN_HEIGHT_TALLEST, // NOVA EDIT ADDITION - HEIGHT_SCALING
 	)
 
 /datum/dna_block/identity/height/create_unique_block(mob/living/carbon/human/target)
 	var/max_height_index = length(dna_heights)
-	var/mob_height_index = dna_heights.Find("[target.get_base_mob_height()]") || dna_heights.Find(HUMAN_HEIGHT_MEDIUM)
+	var/mob_height_index = dna_heights.Find(target.get_base_mob_height()) || dna_heights.Find(HUMAN_HEIGHT_MEDIUM)
 	return construct_block(mob_height_index, max_height_index, block_length)
 
 /datum/dna_block/identity/height/apply_to_mob(mob/living/carbon/human/target, dna_hash)


### PR DESCRIPTION

## About The Pull Request
Early mirror of https://github.com/NovaSector/NovaSector/pull/7155, which is in turn an early mirror of https://github.com/tgstation/tgstation/pull/95732. Fixes height prefs not applying to non-ghostrole characters.
## Why it's Good for the Game
It isn't. 
## Proof of Testing

I ain't doin' all that. Don't merge this. Or do. I'm not your ma.

## Changelog
:cl: Neocloudy
fix: DNA mob height doesn't instantly fall back to the base height for all mobs.
/:cl:
