### PR TITLE
Changes surface-level mentions of Central Command to Sectorial Command

### DIFF
--- a/code/__HELPERS/names.dm
+++ b/code/__HELPERS/names.dm
@@ -76,7 +76,7 @@ GLOBAL_VAR(command_name)
 	if (GLOB.command_name)
 		return GLOB.command_name
 
-	var/name = "Central Command"
+	var/name = "Sectorial Command" // OCULIS EDIT - Central Command > Sectorial Command
 
 	GLOB.command_name = name
 	return name

--- a/code/controllers/subsystem/shuttle.dm
+++ b/code/controllers/subsystem/shuttle.dm
@@ -335,7 +335,7 @@ SUBSYSTEM_DEF(shuttle)
 
 	switch(emergency.mode)
 		if(SHUTTLE_RECALL)
-			return "The emergency shuttle may not be called while returning to CentCom."
+			return "The emergency shuttle may not be called while returning to Castor Station." // OCULIS EDIT - CentCom > Castor Station
 		if(SHUTTLE_CALL)
 			return "The emergency shuttle is already on its way."
 		if(SHUTTLE_DOCKED)
@@ -345,7 +345,7 @@ SUBSYSTEM_DEF(shuttle)
 		if(SHUTTLE_ESCAPE)
 			return "The emergency shuttle is moving away to a safe distance."
 		if(SHUTTLE_STRANDED)
-			return "The emergency shuttle has been disabled by CentCom."
+			return "The emergency shuttle has been disabled by Sectorial Command." // OCULIS EDIT - CentCom > Sectorial Command
 
 	return TRUE
 

--- a/code/controllers/subsystem/ticker.dm
+++ b/code/controllers/subsystem/ticker.dm
@@ -488,7 +488,7 @@ SUBSYSTEM_DEF(ticker)
 				[reopened_job_report_positions]</i>
 			"}
 
-			print_command_report(suicide_command_report, "Central Command Personnel Update")
+			print_command_report(suicide_command_report, "Sectorial Command Personnel Update") // OCULIS EDIT - Central Command > Sectorial Command
 
 //These callbacks will fire after roundstart key transfer
 /datum/controller/subsystem/ticker/proc/OnRoundstart(datum/callback/cb)

--- a/code/datums/personality/reaction_to_nt.dm
+++ b/code/datums/personality/reaction_to_nt.dm
@@ -26,7 +26,7 @@
 /datum/personality/nt/loyalist
 	savefile_key = "loyalist"
 	name = "Loyal"
-	desc = "I believe in the station and in Central Command, till the very end!"
+	desc = "I believe in the station and in Sectorial Command, till the very end!" // OCULIS EDIT - Central Command > Sectorial Command
 	pos_gameplay_desc = "Likes company posters and signs"
 	mood_event_type = /datum/mood_event/nt_loyalist
 

--- a/code/datums/pod_style.dm
+++ b/code/datums/pod_style.dm
@@ -25,15 +25,15 @@
 /datum/pod_style/advanced
 	name = "bluespace supply pod"
 	ui_name = "Advanced"
-	desc = "A Nanotrasen Bluespace supply pod. Teleports back to CentCom after delivery."
+	desc = "A Nanotrasen Bluespace supply pod. Teleports back to Castor Station after delivery." // OCULIS EDIT - CentCom > Castor Station
 	decal_icon = "bluespace"
 	glow_color = "blue"
 	id = "bluespace"
 
 /datum/pod_style/centcom
-	name = "\improper CentCom supply pod"
+	name = "\improper Sectorial Command supply pod" // OCULIS EDIT - \improper CentCom > Sectorial Command
 	ui_name = "Nanotrasen"
-	desc = "A Nanotrasen supply pod. This one has been marked with Central Command's designations. Teleports back to CentCom after delivery."
+	desc = "A Nanotrasen supply pod. This one has been marked with Sectorial Command's designations. Teleports back to Castor Station after delivery." // OCULIS EDIT - CentCom > Castor Station
 	decal_icon = "centcom"
 	glow_color = "blue"
 	id = "centcom"

--- a/code/game/gamemodes/objective.dm
+++ b/code/game/gamemodes/objective.dm
@@ -597,7 +597,7 @@ GLOBAL_LIST_EMPTY(objectives) //NOVA EDIT ADDITION
 
 /datum/objective/exile
 	name = "exile"
-	explanation_text = "Stay alive off station. Do not go to CentCom."
+	explanation_text = "Stay alive off station. Do not go to Castor Station." // OCULIS EDIT - CentCom > Castor Station
 
 /datum/objective/exile/check_completion()
 	var/list/owners = get_owners()

--- a/code/game/machinery/civilian_bounties.dm
+++ b/code/game/machinery/civilian_bounties.dm
@@ -4,7 +4,7 @@
 ///Pad for the Civilian Bounty Control.
 /obj/machinery/piratepad/civilian
 	name = "civilian bounty pad"
-	desc = "A machine designed to send civilian bounty targets to centcom."
+	desc = "A machine designed to send civilian bounty targets to Castor Station." // OCULIS EDIT - CentCom > Castor Station
 	layer = TABLE_LAYER
 	resistance_flags = FIRE_PROOF
 	circuit = /obj/item/circuitboard/machine/bountypad

--- a/code/game/machinery/computer/communications.dm
+++ b/code/game/machinery/computer/communications.dm
@@ -212,7 +212,7 @@ GLOBAL_VAR_INIT(cops_arrived, FALSE)
 			if (new_sec_level < SEC_LEVEL_GREEN || new_sec_level > SEC_LEVEL_AMBER) //NOVA EDIT CHANGE - ALERTS
 				return
 			if (SSsecurity_level.get_current_level_as_number() >= SEC_LEVEL_DELTA)
-				to_chat(user, span_warning("Central Command has placed a lock on the alert level due to a doomsday!"))
+				to_chat(user, span_warning("Sectorial Administration has placed a lock on the alert level due to a doomsday!")) // OCULIS EDIT - Central Command > Sectorial Administration
 				return
 			if (SSsecurity_level.get_current_level_as_number() == new_sec_level)
 				return
@@ -257,9 +257,9 @@ GLOBAL_VAR_INIT(cops_arrived, FALSE)
 				to_chat(user, span_danger("Message transmitted to Syndicate Command."))
 			else
 				message_centcom(message, user)
-				to_chat(user, span_notice("Message transmitted to Central Command."))
+				to_chat(user, span_notice("Message transmitted to Sectorial Command.")) // OCULIS EDIT - Central Command > Sectorial Command
 
-			var/associates = (emagged || syndicate) ? "the Syndicate": "CentCom"
+			var/associates = (emagged || syndicate) ? "the Syndicate": "Sectorial Command" // OCULIS EDIT - CentCom > Sectorial Command
 			user.log_talk(message, LOG_SAY, tag = "message to [associates]")
 			deadchat_broadcast(" has messaged [associates], \"[message]\" at [span_name("[get_area_name(user, TRUE)]")].", span_name("[user.real_name]"), user, message_type = DEADCHAT_ANNOUNCEMENT)
 			COOLDOWN_START(src, important_action_cooldown, IMPORTANT_ACTION_COOLDOWN)

--- a/code/game/objects/items/cards_ids.dm
+++ b/code/game/objects/items/cards_ids.dm
@@ -899,7 +899,7 @@
 			. += span_notice("Alt-Right-Click the ID to set the linked bank account.")
 
 	if(HAS_TRAIT(user, TRAIT_ID_APPRAISER))
-		. += HAS_TRAIT(src, TRAIT_JOB_FIRST_ID_CARD) ? span_boldnotice("Hmm... yes, this ID was issued from Central Command!") : span_boldnotice("This ID was created in this sector, not by Central Command.")
+		. += HAS_TRAIT(src, TRAIT_JOB_FIRST_ID_CARD) ? span_boldnotice("Hmm... yes, this ID was issued from Sectorial Command!") : span_boldnotice("This ID was created in this sector, not by Sectorial Command.") // OCULIS EDIT - Central Command > Sectorial Command
 		if(HAS_TRAIT(src, TRAIT_TASTEFULLY_THICK_ID_CARD) && (user.is_holding(src) || (IsReachableBy(user) && user.put_in_hands(src, ignore_animation = FALSE))))
 			ADD_TRAIT(src, TRAIT_NODROP, "psycho")
 			. += span_hypnophrase("Look at that subtle coloring... The tasteful thickness of it. Oh my God, it even has a watermark...")

--- a/code/modules/admin/smites/dock_pay.dm
+++ b/code/modules/admin/smites/dock_pay.dm
@@ -22,10 +22,10 @@
 	if (!new_cost)
 		return
 	if(new_cost < 0)
-		card.registered_account.adjust_money(new_cost, "Central Command: Pay Bonus")
-		card.registered_account.bank_card_talk("[new_cost] [MONEY_NAME] added to your account based on performance review by Central Command.", force = TRUE)
+		card.registered_account.adjust_money(new_cost, "Sectorial Command: Pay Bonus") // OCULIS EDIT - Central Command > Sectorial Command
+		card.registered_account.bank_card_talk("[new_cost] [MONEY_NAME] added to your account based on performance review by Sectorial Command.", force = TRUE) // OCULIS EDIT - Central Command > Sectorial Command
 	else
-		SSeconomy.add_audit_entry(card.registered_account, new_cost, "Central Command")
-		card.registered_account.adjust_money(-new_cost, "Central Command: Pay Cut")
-		card.registered_account.bank_card_talk("[new_cost] [MONEY_NAME] deducted from your account based on performance review by Central Command.", force = TRUE)
+		SSeconomy.add_audit_entry(card.registered_account, new_cost, "Sectorial Command") // OCULIS EDIT - Central Command > Sectorial Command
+		card.registered_account.adjust_money(-new_cost, "Sectorial Command: Pay Cut") // OCULIS EDIT - Central Command > Sectorial Command
+		card.registered_account.bank_card_talk("[new_cost] [MONEY_NAME] deducted from your account based on performance review by Sectorial Command.", force = TRUE) // OCULIS EDIT - Central Command > Sectorial Command
 	SEND_SOUND(target, 'sound/machines/buzz/buzz-sigh.ogg')

--- a/code/modules/admin/verbs/adminevents.dm
+++ b/code/modules/admin/verbs/adminevents.dm
@@ -60,7 +60,7 @@ ADMIN_VERB_AND_CONTEXT_MENU(cmd_admin_headset_message, R_ADMIN, "Headset Message
 	log_directed_talk(mob, target, input, LOG_ADMIN, "reply")
 	message_admins("[key_name_admin(src)] replied to [key_name_admin(target)]'s [sender] message with: \"[input]\"")
 	target.balloon_alert(target, "you hear a voice")
-	to_chat(target, span_hear("You hear something crackle in your [human_recipient ? "ears" : "radio receiver"] for a moment before a voice speaks. \"Please stand by for a message from [sender == "Syndicate" ? "your benefactor" : "Central Command"]. Message as follows[sender == "Syndicate" ? ", agent." : ":"] <b>[input].</b> Message ends.\""), confidential = TRUE)
+	to_chat(target, span_hear("You hear something crackle in your [human_recipient ? "ears" : "radio receiver"] for a moment before a voice speaks. \"Please stand by for a message from [sender == "Syndicate" ? "your benefactor" : "Sectorial Command"]. Message as follows[sender == "Syndicate" ? ", agent." : ":"] <b>[input].</b> Message ends.\""), confidential = TRUE) // OCULIS EDIT - Central Command > Sectorial Command
 
 	BLACKBOX_LOG_ADMIN_VERB("Headset Message")
 

--- a/code/modules/admin/verbs/commandreport.dm
+++ b/code/modules/admin/verbs/commandreport.dm
@@ -2,7 +2,7 @@
 #define DEFAULT_ANNOUNCEMENT_SOUND "default_announcement"
 
 /// Preset central command names to chose from for centcom reports.
-#define CENTCOM_PRESET "Central Command"
+#define CENTCOM_PRESET "Sectorial Command" // OCULIS EDIT - Central Command > Sectorial Command
 #define SYNDICATE_PRESET "The Syndicate"
 #define WIZARD_PRESET "The Wizard Federation"
 #define CUSTOM_PRESET "Custom Command Name"

--- a/code/modules/clothing/under/accessories/medals.dm
+++ b/code/modules/clothing/under/accessories/medals.dm
@@ -110,7 +110,7 @@
 
 /obj/item/clothing/accessory/medal/gold/heroism
 	name = "medal of exceptional heroism"
-	desc = "An extremely rare golden medal awarded only by CentCom. To receive such a medal is the highest honor and as such, very few exist. This medal is almost never awarded to anybody but commanders."
+	desc = "An extremely rare golden medal awarded only by Sectorial Administrators. To receive such a medal is the highest honor and as such, very few exist. This medal is almost never awarded to anybody but commanders." // OCULIS EDIT - CentCom > Sectorial Administrators
 
 /obj/item/clothing/accessory/medal/plasma
 	name = "plasma medal"

--- a/code/modules/paperwork/fax.dm
+++ b/code/modules/paperwork/fax.dm
@@ -1,4 +1,4 @@
-GLOBAL_VAR_INIT(nt_fax_department, pick("Central Command")) // IRIS EDIT Original: "NT HR Department", "NT Legal Department", "NT Complaint Department", "NT Customer Relations", "Nanotrasen Tech Support", "NT Internal Affairs Dept"
+GLOBAL_VAR_INIT(nt_fax_department, pick("Sectorial Command")) // IRIS EDIT Original: "NT HR Department", "NT Legal Department", "NT Complaint Department", "NT Customer Relations", "Nanotrasen Tech Support", "NT Internal Affairs Dept" // OCULIS EDIT - Central Command > Sectorial Command
 GLOBAL_VAR_INIT(fax_autoprinting, FALSE)
 
 /obj/machinery/fax
@@ -80,7 +80,7 @@ GLOBAL_VAR_INIT(fax_autoprinting, FALSE)
 	return ..()
 
 /obj/machinery/fax/admin
-	name = "CentCom Fax Machine"
+	name = "Sectorial Command Fax Machine"
 
 /obj/machinery/fax/admin/Initialize(mapload)
 	if (!fax_name)

--- a/modular_nova/master_files/code/modules/admin/player_panel.dm
+++ b/modular_nova/master_files/code/modules/admin/player_panel.dm
@@ -190,7 +190,7 @@ GLOBAL_LIST_INIT(pp_limbs, list(
 					to_chat(adminClient, "The person you are trying to contact is not wearing a headset. Unsent message: [msg]")
 					return
 
-				to_chat(selected_mob, "You hear something crackle in your ears for a moment before a voice speaks.  \"Please stand by for a message from [sender == RADIO_CHANNEL_SYNDICATE ? "your benefactor" : "Central Command"].  Message as follows[sender == RADIO_CHANNEL_SYNDICATE ? ", agent." : ":"] <span class='bold'>[msg].</span> Message ends.\"")
+				to_chat(selected_mob, "You hear something crackle in your ears for a moment before a voice speaks.  \"Please stand by for a message from [sender == RADIO_CHANNEL_SYNDICATE ? "your benefactor" : "Sectorial Command"].  Message as follows[sender == RADIO_CHANNEL_SYNDICATE ? ", agent." : ":"] <span class='bold'>[msg].</span> Message ends.\"") // OCULIS EDIT - Central Command > Sectorial Command
 
 
 			log_admin("SubtlePM ([sender]): [key_name(adminClient)] -> [key_name(targetMob)] : [msg]")

--- a/modular_nova/modules/blueshield/code/blueshield.dm
+++ b/modular_nova/modules/blueshield/code/blueshield.dm
@@ -5,7 +5,7 @@
 	faction = FACTION_STATION
 	total_positions = 1
 	spawn_positions = 1
-	supervisors = "Central Command and the Nanotrasen Consultant"
+	supervisors = "Sectorial Administration and the Nanotrasen Consultant" // OCULIS EDIT - Central Command > Sectorial Administration
 	minimal_player_age = 7
 	exp_requirements = 2400
 	exp_required_type = EXP_TYPE_CREW

--- a/modular_nova/modules/nanotrasen_rep/code/nanotrasen_consultant.dm
+++ b/modular_nova/modules/nanotrasen_rep/code/nanotrasen_consultant.dm
@@ -4,7 +4,7 @@
 	faction = FACTION_STATION
 	total_positions = 1
 	spawn_positions = 1
-	supervisors = JOB_CENTCOM
+	supervisors = "Sectorial Administration" // OCULIS EDIT - JOB_CENTCOM > "Sectorial Administration"
 	minimal_player_age = 14
 	exp_requirements = 600
 	exp_required_type = EXP_TYPE_CREW


### PR DESCRIPTION

## About The Pull Request
Replaces multiple mentions of Central Command or CentCom with Sectorial Command, Sectorial Administration or Castor Station as necessary
More can be added as necessary.
Currently Changes:
- automatic and default admin announcement titles
- admin headset message company title 
- Admin fax machine name
- A few item descriptions for things that are examined rather often
- Some other things that I stumbled upon as I was looking through the few hundred files with CC written inside somewhere
## Why it's Good for the Game
Increases Lore consistency and helps with immersion
## Proof of Testing
<img width="650" height="157" alt="image" src="https://github.com/user-attachments/assets/3c298f5a-5999-42a3-8a76-b9e52c5f6165" />
<img width="340" height="540" alt="image" src="https://github.com/user-attachments/assets/15d5b04c-4eca-4950-8c66-73949a358b3b" />

## Changelog
:cl:
code: Replaced some mentions of Central Command with Sectorial Command
/:cl:
