### PR TITLE
Sending furious george to the shadow realm (attempt 2)

### DIFF
--- a/code/modules/mob/living/carbon/human/monkey.dm
+++ b/code/modules/mob/living/carbon/human/monkey.dm
@@ -136,11 +136,13 @@ GLOBAL_DATUM(the_one_and_only_punpun, /mob/living/carbon/human/species/monkey/pu
 		if(ancestor_chain > 1)
 			name_to_use += " \Roman[ancestor_chain]"
 
+	/* // OCULIS EDIT REMOVAL START
 	else if(prob(10))
 		name_to_use = pick(list("Professor Bobo", "Deempisi's Revenge", "Furious George", "King Louie", "Dr. Zaius", "Jimmy Rustles", "Dinner", "Lanky"))
 		if(name_to_use == "Furious George")
 			qdel(ai_controller)
 			ai_controller = new /datum/ai_controller/monkey/angry(src) //hes always mad
+	*/ //OCULIS EDIT REMOVAL END
 #endif
 
 	fully_replace_character_name(real_name, name_to_use)


### PR DESCRIPTION

## About The Pull Request
The Furious George event has caused a bit of an issue here, this PR seeks to remove it from the game.
## Why it's Good for the Game
Many of the RP players that actually play the bartender role don't appreciate their monkey immediately deciding to try and maul them to death shortly after the round starts. Don't get me wrong, it's funny from an LRP perspective... but on an RP server this is a bit much. From an oculis lore perspective, I highly doubt NT is going to put a monkey in that clearly desires nothing more than ripping people apart.
## Proof of Testing
This is kind of difficult to test, but I started new rounds repeatedly and didn't get the furious george event. Uh... RNG could just be blessing me in theory though, so if anyone else knows a better way of testing it and making sure I did this correctly, by all means.
## Changelog
:cl: Spacemanspark
del: Furious George will no longer furiously try to George your skull in when the round starts.
/:cl:
