### PR TITLE
Syndicate bombs now properly scale defusal difficulty with time

### DIFF
--- a/code/game/machinery/syndicatebomb.dm
+++ b/code/game/machinery/syndicatebomb.dm
@@ -233,7 +233,7 @@
 	// 12 booms, 6 duds at ~9 minutes
 	var/datum/wires/syndicatebomb/bomb_wires = wires
 	if(add_boom_wires)
-		var/boom_wires = clamp(round(timer_set / 45, 1), 2, 12)
+		var/boom_wires = round(LERP(2, 12, INVERSE_LERP(minimum_timer, maximum_timer, timer_set)), 1)
 		var/dud_wires = 0
 		if(boom_wires >= 3)
 			dud_wires = floor(boom_wires / 2)

--- a/code/game/machinery/syndicatebomb.dm
+++ b/code/game/machinery/syndicatebomb.dm
@@ -233,7 +233,7 @@
 	// 12 booms, 6 duds at ~9 minutes
 	var/datum/wires/syndicatebomb/bomb_wires = wires
 	if(add_boom_wires)
-		var/boom_wires = round(LERP(2, 12, INVERSE_LERP(minimum_timer, maximum_timer, timer_set)), 1)
+		var/boom_wires = round(LERP(2, 12, INVERSE_LERP(minimum_timer, maximum_timer, timer_set)), 1) // OCULIS EDIT
 		var/dud_wires = 0
 		if(boom_wires >= 3)
 			dud_wires = floor(boom_wires / 2)


### PR DESCRIPTION

## About The Pull Request
This makes syndicate bombs now properly scale difficulty with time, from 2 live wires and no extra duds at minimum time, to 12 live wires and 6 extra duds at maximum time. 
For reference, current minimum times are 600 seconds (10 minutes) and 60000 seconds (1000 minutes).
Maximum time is intended to be 100 minutes, not 1000 minutes, but the pre-existing code is implemented incorrectly. I'll fix this on TG's side.
## Why it's Good for the Game
In the current state, syndicate bombs are nearly impossible to defuse even at the minimum time. They do not currently scale with time as intended. This would reintroduce the incentive to give bombs long fuses, and make them more possible to defuse.
## Proof of Testing
<img width="2564" height="1383" alt="Screenshot 2026-04-25 153638 2" src="https://github.com/user-attachments/assets/bce4f06a-f8ea-49a0-be32-4f84064aa2e8" />
<img width="2560" height="1380" alt="Screenshot 2026-04-25 153713" src="https://github.com/user-attachments/assets/d9fd44e0-f849-4e24-92f8-8c811e1316c8" />
<img width="2560" height="1380" alt="Screenshot 2026-04-25 153743" src="https://github.com/user-attachments/assets/ca0a517f-87ab-4885-ba8f-982c232f423a" />
<img width="2560" height="1380" alt="Screenshot 2026-04-25 153758" src="https://github.com/user-attachments/assets/36f6e262-d237-4b2b-b725-4d3b2671c543" />
<img width="2560" height="1380" alt="Screenshot 2026-04-25 153845" src="https://github.com/user-attachments/assets/f04da237-c241-43ec-8185-fb4bddba4cb9" />
<img width="2560" height="1380" alt="Screenshot 2026-04-25 153852" src="https://github.com/user-attachments/assets/ebe9329d-13dd-442c-b32e-6e8af32e6444" />
<img width="2560" height="1380" alt="Screenshot 2026-04-25 154013" src="https://github.com/user-attachments/assets/f65ee9dc-42f3-4d97-8108-d87c72df2d2a" />
<img width="2560" height="1380" alt="Screenshot 2026-04-25 154021" src="https://github.com/user-attachments/assets/3e3adf83-6725-486e-9641-12f4ea26a079" />

## Changelog
:cl:
fix: Syndicate bombs now properly scale defusal difficulty with time.
/:cl:
