### PR TITLE
Adds all uncommon blood types to the uncommon blood crate

### DIFF
--- a/modular_nova/modules/unusual_biochemistry/reagents.dm
+++ b/modular_nova/modules/unusual_biochemistry/reagents.dm
@@ -38,7 +38,7 @@
 /datum/supply_pack/medical/bloodpacks/uncommon
 	name = "Uncommon Blood Pack Variety Crate"
 	desc = "Contains sixteen different uncommmon blood packs for reintroducing blood to patients." // OCULIS EDIT
-	cost = CARGO_CRATE_VALUE * 11 // about 1.6x the price of regular blood crate, since there's so much more // OCULIS EDIT
+	cost = CARGO_CRATE_VALUE * 11 // about 1.6x the price of regular blood crate, since there's that much more blood in this one // OCULIS EDIT
 	contains = list(
 		/obj/item/reagent_containers/blood/haemocyanin = 2,
 		/obj/item/reagent_containers/blood/chlorocruorin = 2,

--- a/modular_nova/modules/unusual_biochemistry/reagents.dm
+++ b/modular_nova/modules/unusual_biochemistry/reagents.dm
@@ -22,16 +22,32 @@
 /obj/item/reagent_containers/blood/exotic
 	blood_type = "Exotic"
 
+// OCULIS ADDITION START
+
+/obj/item/reagent_containers/blood/haemoglobin
+	blood_type = "Haemoglobin"
+
+/obj/item/reagent_containers/blood/haemotoxin
+	blood_type = "Haemotoxin"
+
+/obj/item/reagent_containers/blood/nanoblood
+	blood_type = "Nanomachine Infused Blood"
+
+// OCULIS ADDITION END
+
 /datum/supply_pack/medical/bloodpacks/uncommon
 	name = "Uncommon Blood Pack Variety Crate"
-	desc = "Contains ten different uncommmon blood packs for reintroducing blood to patients."
-	cost = CARGO_CRATE_VALUE * 7
+	desc = "Contains sixteen different uncommmon blood packs for reintroducing blood to patients." // OCULIS EDIT
+	cost = CARGO_CRATE_VALUE * 11 // about 1.6x the price of regular blood crate, since there's so much more // OCULIS EDIT
 	contains = list(
 		/obj/item/reagent_containers/blood/haemocyanin = 2,
 		/obj/item/reagent_containers/blood/chlorocruorin = 2,
 		/obj/item/reagent_containers/blood/hemerythrin = 2,
 		/obj/item/reagent_containers/blood/pinnaglobin = 2,
 		/obj/item/reagent_containers/blood/exotic = 2,
+		/obj/item/reagent_containers/blood/haemoglobin = 2, // OCULIS ADDITION
+		/obj/item/reagent_containers/blood/haemotoxin = 2, // OCULIS ADDITION
+		/obj/item/reagent_containers/blood/nanoblood = 2, // OCULIS ADDITION
 	)
 	crate_name = "blood freezer"
 	crate_type = /obj/structure/closet/crate/freezer


### PR DESCRIPTION

## About The Pull Request
Creates blood packs for the missing uncommon blood types (haemoglobin, haemotoxin, nanomachine infused blood), adds them to the uncommon blood crate, and increases its price proportionately. It has gone from CARGO_CRATE_VALUE * 7 to CARGO_CRATE_VALUE * 11, approximately 1.6x price, to match the 1.6x increase in product in the crate compared to the standard blood crate.
## Why it's Good for the Game
Medbay can now properly treat all crew with uncommon blood types, not only some of them.
## Proof of Testing
<img width="2560" height="1380" alt="Screenshot 2026-04-25 172908 2" src="https://github.com/user-attachments/assets/224404dc-ca4c-4f21-90dc-555674ed45e8" />
<img width="2560" height="1380" alt="Screenshot 2026-04-25 173210 2" src="https://github.com/user-attachments/assets/4c426f70-41bc-4ff1-b8f0-17a4934dc722" />

## Changelog
:cl:
fix: Fixed the uncommon blood crate not having blood for all uncommon blood types in it. Its price has been increased proportionately.
/:cl:
