### PR TITLE
Permit Locks the NT M-96

### DIFF
--- a/modular_nova/master_files/code/modules/cargo/packs/companies/ballistics.dm
+++ b/modular_nova/master_files/code/modules/cargo/packs/companies/ballistics.dm
@@ -57,9 +57,9 @@
 	cost = CARGO_CRATE_VALUE * 4
 	contains = list(/obj/item/storage/toolbox/guncase/nova/ntspecial/pistol/c96)
 	auto_name = FALSE
-	access = FALSE
-	access_view = FALSE
-	express_lock = FALSE
+	// access = FALSE // OCULIS EDIT
+	// access_view = FALSE // OCULIS EDIT
+	// express_lock = FALSE // OCULIS EDIT
 	order_flags = ORDER_COMPANY
 
 // Sol Fed Weapons


### PR DESCRIPTION

## About The Pull Request
Permit locks and express console locks-out the NT M-96. 
## Why it's Good for the Game
This brings it in line with the other guns, which are currently permit locked. This one not being locked is an oversight because it's new.
## Proof of Testing
<img width="2560" height="1380" alt="image" src="https://github.com/user-attachments/assets/eea9f0da-8903-4052-9e50-b11351705106" />

## Changelog
:cl:
fix: Fixed the NT M-96 not being permit-locked.
/:cl:
