### PR TITLE
no more drunk stowaway spawns

### DIFF
--- a/modular_oculis/modules/quirks/stowaway.dm
+++ b/modular_oculis/modules/quirks/stowaway.dm
@@ -18,9 +18,6 @@
 	card.register_name(effective_alias)
 	stowaway.update_visible_name()
 
-	if(prob(20))
-		stowaway.adjust_drunk_effect(50) //What did I DO last night?
-
 	var/obj/structure/closet/selected_closet = get_unlocked_closed_locker() //Find your new home
 	if(selected_closet)
 		stowaway.forceMove(selected_closet) //Move in


### PR DESCRIPTION

## About The Pull Request

The 20% chance for stowaways to spawn with +50 drunkenness is removed

## Why it's Good for the Game

I get the thought was it would be funny to get drunk and wake up in a locker somewhere unfamiliar but that just isn't how almost anyone actually plays stowaway 

## Proof of Testing

this is so trivial i don't think it needs testing but i will if requested

## Changelog
:cl:
del: Stowaways no longer have a 20% chance to spawn severely drunk
/:cl:
