### PR TITLE
Fix towercap logs going inside machinery when cut (eg. big manipulator)

### DIFF
--- a/code/modules/hydroponics/grown/towercap.dm
+++ b/code/modules/hydroponics/grown/towercap.dm
@@ -88,10 +88,11 @@
 	if(attacking_item.get_sharpness())
 
 		user.balloon_alert(user, "made [plank_count] [plank_name]")
-		// OCULIS EDIT START - prevent logs going inside machinery when someone's buckled to it.
+		// new plank_type(user.loc, plank_count) // OCULIS EDIT REMOVAL
+		// OCULIS EDIT ADDITION START - prevent logs going inside machinery when someone's buckled to it.
 		var/turf/floor = get_turf(user)
 		new plank_type(floor, plank_count)
-		// OCULIS EDIT END
+		// OCULIS EDIT ADDITION END
 		qdel(src)
 		return
 

--- a/code/modules/hydroponics/grown/towercap.dm
+++ b/code/modules/hydroponics/grown/towercap.dm
@@ -88,8 +88,10 @@
 	if(attacking_item.get_sharpness())
 
 		user.balloon_alert(user, "made [plank_count] [plank_name]")
+		// OCULIS EDIT START - prevent logs going inside machinery when someone's buckled to it.
 		var/turf/floor = get_turf(user)
 		new plank_type(floor, plank_count)
+		// OCULIS EDIT END
 		qdel(src)
 		return
 

--- a/code/modules/hydroponics/grown/towercap.dm
+++ b/code/modules/hydroponics/grown/towercap.dm
@@ -88,7 +88,8 @@
 	if(attacking_item.get_sharpness())
 
 		user.balloon_alert(user, "made [plank_count] [plank_name]")
-		new plank_type(user.loc, plank_count)
+		var/turf/floor = get_turf(user)
+		new plank_type(floor, plank_count)
 		qdel(src)
 		return
 


### PR DESCRIPTION

## About The Pull Request

When towercap logs are processed, they drop to user.loc. Normally, this is the floor, but if you're using a big manipulator, that becomes the manipulator itself. This results in the items going inside the machine, and are irrecoverable without deconstructing the machine. This PR fixes this by running get_turf on the user instead, dropping it on the floor no matter what the user happens to be inside.

## Why it's Good for the Game

Wooden planks that bluespace themselves into the manipulator are bad. The manipulator is meant for automation and this problem makes the logs inherently un-automatable for no good reason.

## Proof of Testing

![](https://transfur.science/7y2irdw4)

## Changelog

:cl:
fix: towercap logs & co drop to the floor when processed by big manipulators
/:cl:
