### PR TITLE
Characters with the 'mute' trait can now use the 'Do' command

### DIFF
--- a/code/modules/mob/mob_say.dm
+++ b/code/modules/mob/mob_say.dm
@@ -52,7 +52,7 @@
 
 	QUEUE_OR_CALL_VERB_FOR(VERB_CALLBACK(src, TYPE_PROC_REF(/mob, emote), "me", NONE, message, TRUE), SSspeech_controller)
 
-/mob/try_speak(message, ignore_spam = FALSE, forced = null, filterproof = FALSE)
+/mob/try_speak(message, ignore_spam = FALSE, forced = null, filterproof = FALSE, mute_bypass = FALSE) //Oculis edit: adds 'mute_bypass', specifically to allow the 'Do' command to work for mute characters
 	var/list/filter_result
 	var/list/soft_filter_result
 	if(client && !forced && !filterproof)
@@ -93,7 +93,7 @@
 	if(sigreturn & COMPONENT_CANNOT_SPEAK)
 		return FALSE
 
-	if(!..()) // the can_speak check
+	if(!..() && !mute_bypass) // the can_speak check + OCULIS EDIT: adds mute_bypass check for the Do command
 		if(HAS_MIND_TRAIT(src, TRAIT_MIMING))
 			to_chat(src, span_green("Your vow of silence prevents you from speaking!"))
 		else

--- a/code/modules/projectiles/guns/energy/special.dm
+++ b/code/modules/projectiles/guns/energy/special.dm
@@ -132,7 +132,7 @@
 		return ITEM_INTERACT_BLOCKING
 
 	var/obj/item/stack/sheet = tool
-	if (!sheet.use(1))
+	if (sheet.use(1))
 		return ITEM_INTERACT_BLOCKING
 
 	cell.give(0.2 * STANDARD_CELL_CHARGE * charge_multiplier)

--- a/code/modules/projectiles/guns/energy/special.dm
+++ b/code/modules/projectiles/guns/energy/special.dm
@@ -132,7 +132,7 @@
 		return ITEM_INTERACT_BLOCKING
 
 	var/obj/item/stack/sheet = tool
-	if (sheet.use(1))
+	if (!sheet.use(1))
 		return ITEM_INTERACT_BLOCKING
 
 	cell.give(0.2 * STANDARD_CELL_CHARGE * charge_multiplier)

--- a/modular_nova/modules/roleplay_do/code/do_verbs.dm
+++ b/modular_nova/modules/roleplay_do/code/do_verbs.dm
@@ -14,7 +14,7 @@
 	if (!message || !doverb_checks(message))
 		return
 
-	if (!try_speak(message)) // ensure we pass the vibe check (filters, etc)
+	if (!try_speak(message, mute_bypass = TRUE)) // ensure we pass the vibe check (filters, etc) + OCULIS EDIT: adds 'mute_bypass = TRUE' for mute characters
 		return
 
 	var/name_stub = " (<b>[usr]</b>)"


### PR DESCRIPTION

## About The Pull Request

Fixes an oversight with the Do command from Nova which previously barred characters with the 'Mute' trait from using it.

## Why it's Good for the Game

The 'Do' command is very useful, even/especially for mute characters. Would be nice for them to have access to it.

## Proof of Testing

https://github.com/user-attachments/assets/f248d255-cc73-4992-bf11-1ea1533749e5


## Changelog


:cl:
fix: Characters with the 'mute' quirk/trait can now use the 'Do' command as intended.
/:cl:
