### PR TITLE
Adds the intangible component

### DIFF
--- a/tgstation.dme
+++ b/tgstation.dme
@@ -10034,6 +10034,7 @@
 #include "modular_oculis\master_files\code\modules\projectiles\gun.dm"
 #include "modular_oculis\master_files\code\modules\projectiles\boxes_magazines\ammo_boxes.dm"
 #include "modular_oculis\master_files\modular_nova\master_files\code\controllers\subsystem\dynamic_rulesets_midround.dm"
+#include "modular_oculis\modules\admin\code\intangible_component.dm"
 #include "modular_oculis\modules\admin\code\view_variables.dm"
 #include "modular_oculis\modules\astar\code\astar.dm"
 #include "modular_oculis\modules\astar\code\navigation.dm"


### PR DESCRIPTION

## About The Pull Request
The intangible component is used by admins to only allow select amounts of players to see an atom / hear it.

## Why it's Good for the Game
Adminbus

## Proof of Testing
## Changelog
:cl:
add: Added the intangible component (Adminbus)
/:cl:
