### PR TITLE
Adds internals crate full of nonstandard internals types to black market ghost role

### DIFF
--- a/_maps/RandomRuins/SpaceRuins/nova/blackmarket.dmm
+++ b/_maps/RandomRuins/SpaceRuins/nova/blackmarket.dmm
@@ -889,6 +889,36 @@
 /obj/structure/cable,
 /turf/open/floor/iron/smooth_large,
 /area/ruin/space/has_grav/nova/blackmarket)
+"MG" = (
+/obj/structure/cable,
+/obj/structure/closet/crate/internals,
+/obj/item/tank/internals/plasmaman/full,
+/obj/item/tank/internals/plasmaman/belt/full{
+	pixel_x = -10
+	},
+/obj/item/tank/internals/plasmaman/belt/full{
+	pixel_x = -5
+	},
+/obj/item/tank/internals/plasmaman/belt/full,
+/obj/item/tank/internals/plasmaman/belt/full{
+	pixel_x = 6
+	},
+/obj/item/tank/internals/nitrogen/belt/full{
+	pixel_y = 2;
+	pixel_x = -4
+	},
+/obj/item/tank/internals/nitrogen/belt/full{
+	pixel_x = 7;
+	pixel_y = -1
+	},
+/obj/item/tank/internals/nitrogen/belt/full{
+	pixel_x = -7;
+	pixel_y = 4
+	},
+/obj/item/tank/internals/nitrogen/belt/full,
+/obj/item/tank/internals/nitrogen/full,
+/turf/open/floor/catwalk_floor/iron_dark,
+/area/ruin/space/has_grav/nova/blackmarket)
 "MN" = (
 /obj/effect/spawner/random/trash/bin,
 /obj/effect/turf_decal/bot_white,
@@ -1561,7 +1591,7 @@ Zh
 Zh
 Zh
 Zh
-KV
+MG
 KV
 De
 hd


### PR DESCRIPTION
## About The Pull Request
This adds an internals crate to the black market ghost role that has uncommon internals types (plasma, n2)
Specifically it has 4 small internals of both plasma and nitrogen and 1 large back tank of plasma and nitrogen
## Why it's Good for the Game
Allows for unique characters to be independent traders as I think it would be interesting to have voxs or plasmamen be free in shadier parts of the sector.
## Proof of Testing
Launched the game and debugspawned the black market area

<img width="364" height="378" alt="image" src="https://github.com/user-attachments/assets/5a2b3c3d-4c82-4388-bab2-641a192c7ef5" />

## Changelog
:cl: Z Man Wit Z Plan
qol: Added an internals crate to Black Market Trader ruin that contains nonstandard internals types, plasmamen and voxs rejoice!
/:cl:
