### PR TITLE
Makes the blackmarket trader ruin always spawn

### DIFF
--- a/modular_nova/modules/mapping/code/space.dm
+++ b/modular_nova/modules/mapping/code/space.dm
@@ -84,8 +84,8 @@
 	suffix = "blackmarket.dmm"
 	name = "Space-Ruin Shady Market"
 	description = "Whaddya buyin'?"
-	always_place = TRUE
-	cost = 0 //as any always place ruin should be, lets other ruins populate with this one not hogging anything
+	always_place = TRUE // OCULIS EDIT CHANGE - ORIGINAL: always_place = FALSE
+	cost = 0 // OCULIS EDIT CHANGE - ORIGINAL: cost = 1
 
 /datum/map_template/ruin/space/nova/shuttle8532
 	id = "shuttle8532"

--- a/modular_nova/modules/mapping/code/space.dm
+++ b/modular_nova/modules/mapping/code/space.dm
@@ -84,6 +84,8 @@
 	suffix = "blackmarket.dmm"
 	name = "Space-Ruin Shady Market"
 	description = "Whaddya buyin'?"
+	always_place = TRUE
+	cost = 0 //as any always place ruin should be, lets other ruins populate with this one not hogging anything
 
 /datum/map_template/ruin/space/nova/shuttle8532
 	id = "shuttle8532"


### PR DESCRIPTION

## About The Pull Request

Makes the blackmarket trader ruin always spawn, as I think it is a pretty creative ruin that has pretty entertaining crew interactions. Along with that it sets the cost of the ruin to 0 so it doesn't clog up spawning for other ruins.
## Why it's Good for the Game

More crew interaction is always good, the black market trader has quickly become one of my favorite ghost roles and as such I'd like to see it more often. Having a use for security (removing contraband, dealing with parking violations, etc) on lower threat rounds I think would provide some interesting engagement as well as letting the crew access items not usually seen more consistently.
## Proof of Testing

Code compiled, server ran, and it successfully spawned.
<img width="1233" height="920" alt="image" src="https://github.com/user-attachments/assets/6aeddc57-3afc-42d9-a86c-a33a036f59b3" />
## Changelog
:cl: Z Man Wit Z Plan
config: made the black market trader be a guaranteed spawn every round.
/:cl:
