### PR TITLE
Removes oversized people getting special guts

### DIFF
--- a/modular_nova/modules/oversized/code/oversized_quirk.dm
+++ b/modular_nova/modules/oversized/code/oversized_quirk.dm
@@ -34,7 +34,7 @@
 	human_holder.physiology.hunger_mod *= OVERSIZED_HUNGER_MOD //50% hungrier
 	human_holder.add_movespeed_modifier(/datum/movespeed_modifier/oversized)
 
-	human_holder.dna.species.gain_oversized_organs(human_holder, src) // handles the addition of oversized organs (species default is a plain oversized stomach)
+	// human_holder.dna.species.gain_oversized_organs(human_holder, src) // handles the addition of oversized organs (species default is a plain oversized stomach) // OCULIS EDIT REMOVAL
 
 /datum/quirk/oversized/remove()
 	var/mob/living/carbon/human/human_holder = quirk_holder


### PR DESCRIPTION

## About The Pull Request
see title

## Why it's Good for the Game
No more ethereals and other people fucking dying on spawn.

## Proof of Testing
## Changelog
:cl:
fix: Fixed oversized people getting huge guts, causing some species to die on the spot.
/:cl:
