### PR TITLE
Fixes duplicate Interdyne cargo entries and outdated stuff in the Interdyne medkits.

### DIFF
--- a/modular_nova/modules/company_imports/code/armament_datums/interdyne_pharmaceuticals.dm
+++ b/modular_nova/modules/company_imports/code/armament_datums/interdyne_pharmaceuticals.dm
@@ -65,20 +65,8 @@
 	contains = list(/obj/item/storage/medkit/tactical/premium/interdyne/empty = 3,)
 	cost = CARGO_CRATE_VALUE * 1.5
 
-/datum/supply_pack/companies/medical/interdyne/doctorkit
-	name = "Interdyne Doctor Kit"
-	desc = "A surgical kit designed for surgical aid, made by doctors for doctors!"
-	contains = list(/obj/item/storage/medkit/tactical/premium/interdyne )
-	cost = CARGO_CRATE_VALUE * 5
-
-/datum/supply_pack/companies/medical/interdyne/doctorkit_bulk
-	name = "Multi Pack of Interdyne Doctor Kits"
-	desc = "Multiple surgical trauma kits, made by doctors, for doctors."
-	contains = list(/obj/item/storage/medkit/tactical/premium/interdyne = 3 )
-	cost = CARGO_CRATE_VALUE * 13.5
-
 /datum/supply_pack/companies/medical/interdyne/large_traumakit
-	name = "Interdyne Large Trauma Kits"
+	name = "Interdyne Large Trauma Kit"
 	desc = "A trauma kit designed for immediate medical aid, made by doctors for doctors!"
 	contains = list(/obj/item/storage/medkit/tactical/premium/interdyne )
 	cost = CARGO_CRATE_VALUE * 5
@@ -111,18 +99,6 @@
 	name = "Multi Pack of Interdyne Surgical Kit"
 	desc = "Multiple surgical kits, made by doctors, for doctors."
 	contains = list(/obj/item/storage/medkit/tactical/premium/interdyne/medium/surgical = 3)
-	cost = CARGO_CRATE_VALUE * 9
-
-/datum/supply_pack/companies/medical/interdyne/medium_kit_oxytoxloss
-	name = "Interdyne OxyTox Trauma Kit"
-	desc = "A kit filled with oxygen and toxins related ailments, made by doctors, for doctors."
-	contains = list(/obj/item/storage/medkit/tactical/premium/interdyne/medium/Tox_Oxy)
-	cost = CARGO_CRATE_VALUE * 3.5
-
-/datum/supply_pack/companies/medical/interdyne/medium_kit_oxytoxloss_bulk
-	name = "Multi Pack of Interdyne OxyTox Trauma Kit"
-	desc = "Multiple trauma kits filled with oxygen and toxins related ailments, made by doctors, for doctors."
-	contains = list(/obj/item/storage/medkit/tactical/premium/interdyne/medium/Tox_Oxy = 3)
 	cost = CARGO_CRATE_VALUE * 9
 
 /datum/supply_pack/companies/medical/interdyne/firstaidkit
@@ -187,7 +163,7 @@
 
 /datum/supply_pack/companies/medical/interdyne/biohazard_box
 	name = "Interdyne Biohazard Response Box"
-	desc = "Multiple surgical trauma kits, made by doctors, for doctors."
+	desc = "Oh god what the fuck did you do to have to order this"
 	contains = list(
 		/obj/item/clothing/suit/bio_suit/interdyne = 3,
 		/obj/item/clothing/head/bio_hood/interdyne = 3,

--- a/modular_nova/modules/company_imports/code/armament_datums/interdyne_pharmaceuticals.dm
+++ b/modular_nova/modules/company_imports/code/armament_datums/interdyne_pharmaceuticals.dm
@@ -163,7 +163,7 @@
 
 /datum/supply_pack/companies/medical/interdyne/biohazard_box
 	name = "Interdyne Biohazard Response Box"
-	desc = "Oh god what the fuck did you do to have to order this"
+	desc = "Oh god what the fuck did you do to have to order this."
 	contains = list(
 		/obj/item/clothing/suit/bio_suit/interdyne = 3,
 		/obj/item/clothing/head/bio_hood/interdyne = 3,

--- a/modular_nova/modules/company_imports/code/objects/interdyne/interdyne_kits.dm
+++ b/modular_nova/modules/company_imports/code/objects/interdyne/interdyne_kits.dm
@@ -62,7 +62,7 @@
 	new_icon_state = "interdyne_premium_surgical"
 
 /obj/item/storage/medkit/tactical/premium/interdyne
-	name = "\improper Interdyne Premium Doctor's Kit"
+	name = "\improper Interdyne Trauma Kit"
 	desc = "a kit specially made by the interdyne corporation to utilize the most essential tools."
 	icon_state = "interdyne_premium_surgical"
 	icon = 'modular_nova/master_files/icons/obj/storage/medkit.dmi'
@@ -87,11 +87,11 @@
 		/obj/item/retractor/advanced = 1,
 		/obj/item/cautery/advanced = 1,
 		/obj/item/defibrillator/compact/combat/loaded/interdyne = 1,
-		/obj/item/circular_saw/field_medic/lowforce = 1,
-		/obj/item/bonesetter = 1,
-		/obj/item/stack/medical/wrap/sticky_tape/surgical = 1,
+		/obj/item/blood_filter/advanced = 1,
+		/obj/item/stack/medical/wrap/sticky_tape/surgical = 2,
 		/obj/item/reagent_containers/medigel/sterilizine = 1,
-		/obj/item/stack/medical/bone_gel = 1,
+		/obj/item/stack/medical/bone_gel = 2,
+		/obj/item/emergency_bed = 1,
 	)
 	generate_items_inside(items_inside, src)
 
@@ -193,28 +193,6 @@
 	var/list/items_inside = list()
 	generate_items_inside(items_inside,src)
 
-/obj/item/storage/medkit/tactical/premium/interdyne/medium/Tox_Oxy
-	name = "\improper Interdyne Critical Burn-Brute Kit"
-	desc = "a kit specially made by the interdyne corporation to utilize the most essential tools. Meant for treating critical bruises"
-	icon_state = "interdyne_brute"
-
-/obj/item/storage/medkit/tactical/premium/interdyne/medium/Tox_Oxy/PopulateContents()
-	var/list/items_inside = list(
-		/obj/item/stack/medical/suture/medicated = 2,
-		/obj/item/stack/medical/mesh/advanced = 2,
-		/obj/item/healthanalyzer/advanced = 1,
-		/obj/item/stack/medical/wrap/gauze = 2,
-		/obj/item/storage/box/bandages/interdyne = 1,
-		/obj/item/storage/box/bandages/interdyne/burn = 1,
-		/obj/item/reagent_containers/hypospray/medipen/morphine = 2,
-		/obj/item/reagent_containers/hypospray/medipen = 2,
-		/obj/item/storage/hypospraykit/interdyne = 1,
-		/obj/item/reagent_containers/cup/beaker/dyne_brutemix = 2,
-		/obj/item/reagent_containers/cup/beaker/dyne_burnmix= 2,
-		/obj/item/reagent_containers/spray/hercuri = 1,
-	)
-	generate_items_inside(items_inside,src)
-
 /obj/item/storage/medkit/tactical/premium/interdyne/medium/surgical
 	name = "\improper Interdyne Field Surgical Kit"
 	desc = "a kit specially made by the interdyne corporation to utilize the most essential tools. Meant for fielld surgeries."
@@ -225,14 +203,14 @@
 		/obj/item/scalpel/advanced = 1,
 		/obj/item/retractor/advanced = 1,
 		/obj/item/cautery/advanced = 1,
-		/obj/item/bonesetter = 1,
+		/obj/item/blood_filter/advanced = 1,
 		/obj/item/surgical_drapes = 1,
 		/obj/item/reagent_containers/hypospray/medipen/morphine = 2,
 		/obj/item/stack/medical/wrap/sticky_tape/surgical = 3,
 		/obj/item/stack/medical/bone_gel = 3,
 		/obj/item/storage/pill_bottle/painkiller = 2,
 		/obj/item/reagent_containers/medigel/sterilizine = 2,
-		/obj/item/stack/medical/wrap/gauze/sterilized = 3,
+		/obj/item/emergency_bed = 1,
 	)
 	generate_items_inside(items_inside,src)
 

--- a/modular_nova/modules/company_imports/code/objects/interdyne/interdyne_kits.dm
+++ b/modular_nova/modules/company_imports/code/objects/interdyne/interdyne_kits.dm
@@ -27,7 +27,7 @@
 	lefthand_file = 'modular_nova/master_files/icons/mob/inhands/equipment/medical_lefthand.dmi'
 	righthand_file = 'modular_nova/master_files/icons/mob/inhands/equipment/medical_righthand.dmi'
 	inhand_icon_state = "dynepaddles0"
-	base_icon_state = "dynepaddles0"
+	base_icon_state = "ippaddles0"
 
 /datum/atom_skin/interdyne_premiumkit
 	abstract_type = /datum/atom_skin/interdyne_premiumkit

--- a/modular_nova/modules/company_imports/code/objects/interdyne/interdyne_kits.dm
+++ b/modular_nova/modules/company_imports/code/objects/interdyne/interdyne_kits.dm
@@ -27,7 +27,7 @@
 	lefthand_file = 'modular_nova/master_files/icons/mob/inhands/equipment/medical_lefthand.dmi'
 	righthand_file = 'modular_nova/master_files/icons/mob/inhands/equipment/medical_righthand.dmi'
 	inhand_icon_state = "dynepaddles0"
-	base_icon_state = "ippaddles0"
+	base_icon_state = "dynepaddles0"
 
 /datum/atom_skin/interdyne_premiumkit
 	abstract_type = /datum/atom_skin/interdyne_premiumkit

--- a/modular_nova/modules/deforest_medical_items/code/storage_items.dm
+++ b/modular_nova/modules/deforest_medical_items/code/storage_items.dm
@@ -393,6 +393,7 @@
 		/obj/item/handheld_soulcatcher,
 		/obj/item/wrench/medical,
 		/obj/item/emergency_bed,
+		/obj/item/defibrillator/compact,
 		/obj/item/storage/box/bandages,
 		/obj/item/bodybag,
 	))

--- a/modular_nova/modules/deforest_medical_items/code/storage_items.dm
+++ b/modular_nova/modules/deforest_medical_items/code/storage_items.dm
@@ -330,7 +330,7 @@
 
 /datum/storage/duffel/deforest_big_surgery
 	max_total_storage = 14 * WEIGHT_CLASS_NORMAL
-	max_slots = 14
+	max_slots = 21
 
 /datum/storage/duffel/deforest_big_surgery/New()
 	. = ..()


### PR DESCRIPTION

## About The Pull Request

Unfucks the duplicate cargo entries n shit that give you the same medkit. And also obliterates the shit out of that dumbass order that advertises itself as an oxy/tox healing kit, delivers one labelled as brute/burn, and has the same contents as the standard dyne medkit. how. also yeah uhhh adjusts the content of sum of the medkits and makes. most of em able to actually fit their contents. you get my vibe. im tired.

## Why it's Good for the Game

uhh. yeyah. bugs. n shyt,.. bad. and also outdated inconsistent shit. yknow.

## Proof of Testing

<img width="621" height="268" alt="Screenshot 2026-05-19 220945" src="https://github.com/user-attachments/assets/b1f386a6-205d-467c-9a9e-6aea84876c8c" />
<img width="392" height="70" alt="Screenshot 2026-05-19 220640" src="https://github.com/user-attachments/assets/8b0edfaf-ac1b-48c6-8024-efc65630d5ca" />


## Changelog
:cl:
qol: Adjusts the contents of the interdyne medkits to have the proper updated surgical kits. and other surgical equipment.
fix: Interdyne medkits now fit the things they fit.
fix: Removed obsolete duplicate cargo entries for interdyne
fix: The interdyne biohazard crate no longer says some shit about some "surgical tools"
/:cl:
