### PR TITLE
PORT: Let's you paint items in loadout and spray can coloring modes

### DIFF
--- a/code/__DEFINES/~nova_defines/loadouts.dm
+++ b/code/__DEFINES/~nova_defines/loadouts.dm
@@ -16,10 +16,6 @@
 
 /// Used to set custom descriptions.
 #define INFO_DESCRIBED "description"
-// OCULIS EDIT ADDITION START
-#define INFO_CUSTOM_COLOR "custom_color"
-#define INFO_COLOR_MODE "color_mode"
-// OCULIS EDIT ADDITION END
 
 /// Max amonut of misc / backpack items that are allowed.
 #define MAX_ALLOWED_MISC_ITEMS 3

--- a/code/__DEFINES/~nova_defines/loadouts.dm
+++ b/code/__DEFINES/~nova_defines/loadouts.dm
@@ -16,6 +16,10 @@
 
 /// Used to set custom descriptions.
 #define INFO_DESCRIBED "description"
+// OCULIS EDIT ADDITION START
+#define INFO_CUSTOM_COLOR "custom_color"
+#define INFO_COLOR_MODE "color_mode"
+// OCULIS EDIT ADDITION END
 
 /// Max amonut of misc / backpack items that are allowed.
 #define MAX_ALLOWED_MISC_ITEMS 3

--- a/code/__DEFINES/~~oculis_defines/loadout.dm
+++ b/code/__DEFINES/~~oculis_defines/loadout.dm
@@ -1,0 +1,3 @@
+/// Used to support spraypaint style item coloration
+#define INFO_CUSTOM_COLOR "custom_color"
+#define INFO_COLOR_MODE "color_mode"

--- a/code/game/objects/items/crayons.dm
+++ b/code/game/objects/items/crayons.dm
@@ -197,6 +197,10 @@
 	)
 	/// Combined lists
 	var/static/list/all_drawables = graffiti + symbols + drawings + oriented + runes + graffiti_large_h
+	// OCULIS EDIT ADDITION START
+	var/washable_coloring_mode = TRUE
+	var/remove_coloring = FALSE
+	// OCULIS EDIT ADDITION END
 
 /obj/item/toy/crayon/proc/isValidSurface(surface)
 	return isfloorturf(surface)
@@ -385,6 +389,10 @@
 	.["can_change_colour"] = can_change_colour
 	.["selected_color"] = GLOB.pipe_color_name[paint_color] || paint_color
 	.["paint_colors"] = GLOB.pipe_paint_colors
+	// OCULIS EDIT ADDITION START
+	.["washable_coloring_mode"] = washable_coloring_mode
+	.["remove_coloring"] = remove_coloring
+	// OCULIS EDIT ADDITION END
 
 /obj/item/toy/crayon/ui_act(action, list/params, datum/tgui/ui, datum/ui_state/state)
 	. = ..()
@@ -427,6 +435,16 @@
 			. = TRUE
 			paint_mode = PAINT_NORMAL
 			drawtype = "a"
+		// OCULIS EDIT ADDITION START
+		if("change_color_mode") //bubber addition
+			if(has_cap)
+				washable_coloring_mode = !washable_coloring_mode
+				. = TRUE
+		if("toggle_remove_coloring") //bubber addition
+			if(has_cap)
+				remove_coloring = !remove_coloring
+				. = TRUE
+		// OCULIS EDIT ADDITION END
 	update_appearance()
 
 /obj/item/toy/crayon/proc/crayon_text_strip(text)
@@ -897,6 +915,12 @@
 	if(check_empty(user))
 		return ITEM_INTERACT_BLOCKING
 
+	// OCULIS EDIT ADDITION START
+	if(remove_coloring && isitem(target))
+		target.remove_atom_colour(FIXED_COLOUR_PRIORITY)
+		return ITEM_INTERACT_SUCCESS
+	// OCULIS EDIT ADDITION END
+
 	if (isbodypart(target))
 		if (color_limb(target, user))
 			return ITEM_INTERACT_SUCCESS
@@ -926,7 +950,7 @@
 		var/fraction = min(1, . / reagents.maximum_volume)
 		reagents.expose(carbon_target, VAPOR, fraction * volume_multiplier)
 
-	else if(actually_paints && target.is_atom_colour(paint_color, min_priority_index = WASHABLE_COLOUR_PRIORITY))
+	else if(actually_paints && target.is_atom_colour(paint_color, min_priority_index = washable_coloring_mode ? WASHABLE_COLOUR_PRIORITY : FIXED_COLOUR_PRIORITY)) //OCULIS EDIT - ORIGINAL else if(actually_paints && target.is_atom_colour(paint_color, min_priority_index = WASHABLE_COLOUR_PRIORITY))
 		balloon_alert(user, "[target.p_theyre()] already that color!")
 		return ITEM_INTERACT_BLOCKING
 
@@ -980,9 +1004,9 @@
 		target_pipe.paint(paint_color)
 		balloon_alert(user, "painted in [GLOB.pipe_color_name[paint_color]] color")
 	else if (is_type_in_typecache(target, direct_color_types))
-		target.add_atom_colour(paint_color, WASHABLE_COLOUR_PRIORITY)
+		target.add_atom_colour(paint_color, washable_coloring_mode ? WASHABLE_COLOUR_PRIORITY : FIXED_COLOUR_PRIORITY) //OCULIS EDIT CHANGE - ORIGINAL: target.add_atom_colour(paint_color, WASHABLE_COLOUR_PRIORITY)
 	else
-		target.add_atom_colour(color_transition_filter(paint_color, saturation_mode), WASHABLE_COLOUR_PRIORITY)
+		target.add_atom_colour(color_transition_filter(paint_color, saturation_mode), washable_coloring_mode ? WASHABLE_COLOUR_PRIORITY : FIXED_COLOUR_PRIORITY) //OCULIS EDIT CHANGE - ORIGINAL: target.add_atom_colour(color_transition_filter(paint_color, saturation_mode), WASHABLE_COLOUR_PRIORITY)
 
 	if(isitem(target) && isliving(target.loc))
 		var/obj/item/target_item = target

--- a/code/modules/loadout/loadout_items.dm
+++ b/code/modules/loadout/loadout_items.dm
@@ -123,6 +123,48 @@ GLOBAL_LIST_INIT(all_loadout_categories, init_loadout_categories())
 			if(reskin_datum)
 				return set_skin(manager, user, params)
 
+	//OCULIS EDIT ADDITION START
+		if("select_color_simple")
+			return item_color_painting(manager, user)
+
+		if("set_color_mode")
+			return item_color_mode(manager, user)
+
+	return TRUE
+
+/datum/loadout_item/proc/item_color_painting(datum/preference_middleware/loadout/manager, mob/user)
+	if(manager.menu)
+		return FALSE
+
+	var/list/loadout = manager.get_current_loadout()
+	if(!loadout?[item_path])
+		return FALSE
+
+	var/chosen_color = tgui_color_picker(user, "Pick new color. Setting color to pitch black will remove the existing color.", "Repaint item", "#000000")
+	if(isnull(chosen_color))
+		return FALSE
+
+	var/hsl = rgb2num(chosen_color, COLORSPACE_HSL)
+	if(hsl[3] == 0)
+		loadout[item_path][INFO_CUSTOM_COLOR] = null
+	else
+		loadout[item_path][INFO_CUSTOM_COLOR] = chosen_color
+
+	manager.save_current_loadout(loadout)
+	return TRUE
+
+/datum/loadout_item/proc/item_color_mode(datum/preference_middleware/loadout/manager, mob/user)
+	var/list/loadout = manager.get_current_loadout()
+	if(!loadout?[item_path])
+		return FALSE
+
+	if(isnull(loadout[item_path][INFO_COLOR_MODE]))
+		loadout[item_path][INFO_COLOR_MODE] = FALSE
+
+	loadout[item_path][INFO_COLOR_MODE] = !loadout[item_path][INFO_COLOR_MODE]
+	manager.save_current_loadout(loadout)
+	// OCULIS EDIT ADDITION END
+
 	return TRUE
 
 /// Opens up the GAGS editing menu.
@@ -270,6 +312,11 @@ GLOBAL_LIST_INIT(all_loadout_categories, init_loadout_categories())
 		equipped_item.set_greyscale(item_color)
 		update_flag |= equipped_item.slot_flags
 
+	// OCULIS EDIT ADDITION START
+	if(item_details?[INFO_CUSTOM_COLOR] && !istype(equipper, /mob/living/carbon/human/dummy)) //the dummy check makes it not color the item in the loadout because that causes runtimes, joining into the game colors the item as intended. If you want to fix it, start here
+		equipped_item.add_atom_colour(color_transition_filter(item_details[INFO_CUSTOM_COLOR], item_details[INFO_COLOR_MODE] ? SATURATION_OVERRIDE : SATURATION_MULTIPLY), FIXED_COLOUR_PRIORITY)
+	// OCULIS EDIT ADDITION END
+
 	if((loadout_flags & LOADOUT_FLAG_ALLOW_NAMING) && item_details?[INFO_NAMED] && !visuals_only)
 		equipped_item.name = trim(item_details[INFO_NAMED], PREVENT_CHARACTER_TRIM_LOSS(MAX_NAME_LEN))
 		ADD_TRAIT(equipped_item, TRAIT_WAS_RENAMED, "Loadout")
@@ -400,6 +447,22 @@ GLOBAL_LIST_INIT(all_loadout_categories, init_loadout_categories())
 			"button_icon" = FA_ICON_PALETTE,
 			"active_key" = INFO_GREYSCALE,
 		))
+	// OCULIS EDIT ADDITION START
+	else
+		UNTYPED_LIST_ADD(button_list, list(
+			"label" = "Repaint",
+			"act_key" = "select_color_simple",
+			"button_icon" = FA_ICON_PALETTE,
+			"active_key" = INFO_CUSTOM_COLOR,
+		))
+		UNTYPED_LIST_ADD(button_list, list(
+			"label" = "Repainting mode",
+			"act_key" = "set_color_mode",
+			"active_key" = INFO_COLOR_MODE,
+			"active_text" = "Override Color",
+			"inactive_text" = "Multiply Color",
+		))
+	// OCULIS EDIT ADDITION END
 
 	if(loadout_flags & LOADOUT_FLAG_ALLOW_NAMING)
 		UNTYPED_LIST_ADD(button_list, list(

--- a/tgstation.dme
+++ b/tgstation.dme
@@ -552,6 +552,7 @@
 #include "code\__DEFINES\~~oculis_defines\astar.dm"
 #include "code\__DEFINES\~~oculis_defines\colors.dm"
 #include "code\__DEFINES\~~oculis_defines\is_helpers.dm"
+#include "code\__DEFINES\~~oculis_defines\loadout.dm"
 #include "code\__DEFINES\~~oculis_defines\mobs.dm"
 #include "code\__DEFINES\~~oculis_defines\plexora.dm"
 #include "code\__DEFINES\~~oculis_defines\quirks.dm"

--- a/tgui/packages/tgui/interfaces/Crayon.tsx
+++ b/tgui/packages/tgui/interfaces/Crayon.tsx
@@ -30,6 +30,8 @@ export const Crayon = (props) => {
     selected_stencil,
     is_literate_user,
     text_buffer,
+    washable_coloring_mode,
+    remove_coloring,
   } = data;
   const capOrChanges = has_cap || can_change_colour;
 
@@ -52,6 +54,17 @@ export const Crayon = (props) => {
                 <Button
                   content="Custom color"
                   onClick={() => act('custom_color')}
+                />
+              </LabeledList.Item>
+              <LabeledList.Item>
+                <Button
+                  content={washable_coloring_mode ? 'Washable paint' : 'Permanent paint'}
+                  onClick={() => act('change_color_mode')}
+                />
+                <Button
+                  content={remove_coloring ? 'Remove paint mode' : 'Paint mode'}
+                  selected={remove_coloring}
+                  onClick={() => act('toggle_remove_coloring')}
                 />
               </LabeledList.Item>
             </LabeledList>


### PR DESCRIPTION

## About The Pull Request
Ports https://github.com/Bubberstation/Bubberstation/pull/5508 from Bubber. Read original PR for scope and limitations.

Tl;dr you can now repaint non-greyscale items in loadout, without needing to spawn with a spraycan. Unfortunately rendering those items in the character creator causes runtimes, so you'll need to spawn to test. 
## Why it's Good for the Game 
More convenient than spawning with a can of spraypaint, and more accessible to newer players to let them know that form of expression is even an Option. Plus, makes it so loadout gear can't have that recolor removed by washing.
## Proof of Testing
<img width="817" height="550" alt="image" src="https://github.com/user-attachments/assets/72243d6b-4218-47b3-aa47-33b92249211e" />
<img width="227" height="229" alt="image" src="https://github.com/user-attachments/assets/655a4bde-b2ea-4dc8-b70d-2b62aab5d4aa" />

## Changelog
:cl: explosivekitty
add: You can now repaint non-greyscale items in loadout the same way spraycan does
add: Spray cans can color items in such a way water cant remove the paint, and also remove permanent paint
/:cl:
