### PR TITLE
Makes Hairties Hat Compatible

### DIFF
--- a/modular_nova/modules/salon/code/hair_tie.dm
+++ b/modular_nova/modules/salon/code/hair_tie.dm
@@ -21,6 +21,12 @@
 	///how big is the randomized aim radius when flicked
 	var/projectile_aim_radius = 30
 
+// OCULIS EDIT ADDITION START
+/obj/item/clothing/head/hair_tie/Initialize(mapload)
+	. = ..()
+	AddComponent(/datum/component/hat_stabilizer, loose_hat = FALSE)
+// OCULIS EDIT ADDITION END
+
 /obj/item/clothing/head/hair_tie/scrunchie
 	name = "scrunchie"
 	desc = "An elastic hair tie, its fabric is velvet soft."


### PR DESCRIPTION

## About The Pull Request
Gives hairties the hat_stabilizer trait that wigs use, allowing you to fit non-armored hats on top of them.
## Why it's Good for the Game
Very silly that you can't style your hair AND wear a hat at the same time. Honestly I thought I made this PR to Iris like a year ago. Oops.
## Proof of Testing

<img width="504" height="202" alt="image" src="https://github.com/user-attachments/assets/8aa0d372-7482-4241-8382-6c2b6518c148" />
<img width="1005" height="540" alt="image" src="https://github.com/user-attachments/assets/c3942fc0-0d65-45c7-9d4b-dbc4ad9112ed" />

## Changelog
:cl:
add: You can now fit (some) hats on top of hairties
/:cl:
