### PR TITLE
Reduce Marked One Block Chance

### DIFF
--- a/modular_nova/modules/gladiator/code/modules/mob/living/simple_animal/hostile/megafauna/markedone.dm
+++ b/modular_nova/modules/gladiator/code/modules/mob/living/simple_animal/hostile/megafauna/markedone.dm
@@ -65,7 +65,7 @@
 	/// We get stunned whenever we ram into a closed turf
 	var/stunned = FALSE
 	/// Chance to block damage entirely on phases 1 and 4
-	var/block_chance = 50
+	var/block_chance = 15 //OCULIS CHANGE - ORIGINAL: 50 WHY IS IT 50 WHAT THE HELL - I WOULD MAKE THIS ZERO BUT LETS JUST SEE HOW THIS LOOKS FIRST.
 	/// This mob will not attack mobs randomly if not in anger, the time doubles as a check for anger
 	var/anger_timer_id = null
 	/// The cooldown between intros so we don't just spam it


### PR DESCRIPTION

## About The Pull Request

This reduces Marked One boss block chance from a whopping 50% to only 15% (matching his actual sword drop)

## Why it's Good for the Game

So Marked One walks around with 4000 hp, the highest HP of all entities on lavaland. For context bubbles and colossus have 2500 and Legion has a total of 3550, making Marked One the highest HP entity on lavaland with almost no contest. This is all capped off with him having a inexplicable 50% block chance, which pretty much increases his effective HP further and turns the fight from an expression of skill to a boring war of attrition. This paired with the fact he has his almost undodgeable throwing knife attack, and he is capable of winning through player bleed out. I think nerfing his block chance from such an absurd value down to a more reasonable one would be a good change. Id change the block to 0 but I think its ok to test 15 out first and see what some people think.

## Proof of Testing

https://github.com/user-attachments/assets/9f6046fd-ab42-47c6-a5ad-ff7caa440650

## Changelog

:cl:
balance: Marked One now has 15% block instead of 50% (why)
/:cl:

