### PR TITLE
Blacklists Amnestics from allergy table

### DIFF
--- a/code/datums/quirks/negative_quirks/allergic.dm
+++ b/code/datums/quirks/negative_quirks/allergic.dm
@@ -23,6 +23,10 @@
 		/datum/reagent/medicine/sansufentanyl,
 		/datum/reagent/medicine/salglu_solution,
 		/datum/reagent/medicine/albuterol,
+		/datum/reagent/medicine/amnestic, // OCULIS EDIT ADDITION
+		/datum/reagent/medicine/amnestic_b, // OCULIS EDIT ADDITION
+		/datum/reagent/medicine/mnestic, // OCULIS EDIT ADDITION
+		/datum/reagent/medicine/mnestic_x, // OCULIS EDIT ADDITION
 		)
 	var/allergy_string
 


### PR DESCRIPTION

## About The Pull Request
## Why it's Good for the Game

oversight moment

## Proof of Testing
## Changelog
:cl:
fix: You can no longer be allergic to amnestics or mnestics.
/:cl:
