### PR TITLE
Disables The Arena emergency shuttle

### DIFF
--- a/code/datums/shuttles/emergency.dm
+++ b/code/datums/shuttles/emergency.dm
@@ -172,10 +172,11 @@
 	description = "The crew must pass through an otherworldly arena to board this shuttle. Expect massive casualties."
 	prerequisites = "The source of the Bloody Signal must be tracked down and eliminated to unlock this shuttle."
 	admin_notes = "RIP AND TEAR."
-	credit_cost = CARGO_CRATE_VALUE * 20
+	credit_cost = INFINITY // OCULIS EDIT, ORIGINAL: credit_cost = CARGO_CRATE_VALUE * 20
 	occupancy_limit = "1/2"
 	/// Whether the arena z-level has been created
 	var/arena_loaded = FALSE
+	who_can_purchase = null // OCULIS ADDITION
 
 /datum/map_template/shuttle/emergency/arena/prerequisites_met()
 	return SSshuttle.shuttle_purchase_requirements_met[SHUTTLE_UNLOCK_BUBBLEGUM]


### PR DESCRIPTION

## About The Pull Request
Disables The Arena emergency shuttle from being chosen by the shuttle catastrophe event or being bought by players by giving it an infinite cost and null list of who can purchase it.

## Why it's Good for the Game
The Arena is LRP in concept, heavily discourages RP on the shuttle, heavily encourages killing others before EORG, and is barely functional to begin with. Removing it is a huge improvement.

## Proof of Testing
Untested since it's a trivial change, but I can test it if requested.

## Changelog

:cl:
del: Removed The Arena emergency shuttle.
/:cl:

