### PR TITLE
Adds a details block to the Proof of Testing section of the PR template

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -9,10 +9,12 @@
 
 <!-- Please add a short description of why you think these changes would benefit the game and the roleplay atmosphere of the server. If you can't justify it in words, it might not be worth adding. -->
 
-## Proof of Testing
+<details>
+<summary><h2>Proof of Testing</h2></summary>
 
-<!-- Include any screenshots/videos/debugging steps of the code functioning successfully-->
+<!-- Include any screenshots/videos/debugging steps of the code functioning successfully, between the </summary> and </details> code blocks. -->
 <!-- To our mappers and spriters: Posting screenshots of content INSIDE EDITORS (aseprite, PDN, SDMM, ect) is NOT valid proof of testing. Please make sure that you COMPILE the game and provide PROOF you tested your edits. -->
+</details>
 
 ## Changelog
 

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -9,11 +9,14 @@
 
 <!-- Please add a short description of why you think these changes would benefit the game and the roleplay atmosphere of the server. If you can't justify it in words, it might not be worth adding. -->
 
-<details>
-<summary><h2>Proof of Testing</h2></summary>
+## Proof of Testing
 
 <!-- Include any screenshots/videos/debugging steps of the code functioning successfully, between the </summary> and </details> code blocks. -->
 <!-- To our mappers and spriters: Posting screenshots of content INSIDE EDITORS (aseprite, PDN, SDMM, ect) is NOT valid proof of testing. Please make sure that you COMPILE the game and provide PROOF you tested your edits. -->
+
+<details>
+<summary>Screenshots/Videos</summary>
+
 </details>
 
 ## Changelog


### PR DESCRIPTION

## About The Pull Request
Adds a details block to the Proof of Testing section of the pull request template, like Nova Sector has.
## Why it's Good for the Game
Helps keep PRs with a lot of screenshots readable.
## Proof of Testing

<!-- Include any screenshots/videos/debugging steps of the code functioning successfully, between the </summary> and </details> code blocks. -->
<details>
<summary>Screenshots/Videos</summary>
<img width="1081" height="1163" alt="proof of testing" src="https://github.com/user-attachments/assets/3a25a622-29fe-4254-b97d-f233e7d1b953" />


</details>

## Changelog
:cl:
code: Added a details block to the Proof of Testing section
/:cl:
