### PR TITLE
Lets cyborgs pick up airbags with the engineering apparatus

### DIFF
--- a/code/game/objects/items/robot/items/storage.dm
+++ b/code/game/objects/items/robot/items/storage.dm
@@ -300,7 +300,7 @@
 		/obj/item/wallframe,
 		/obj/item/stack/conveyor,
 		/obj/item/stack/tile,
-		/obj/item/vending_refill
+		/obj/item/vending_refill,
 		// NOVA EDIT ADDITION END
 		/obj/item/airbag // OCULIS ADDITION
 	)

--- a/code/game/objects/items/robot/items/storage.dm
+++ b/code/game/objects/items/robot/items/storage.dm
@@ -300,9 +300,9 @@
 		/obj/item/wallframe,
 		/obj/item/stack/conveyor,
 		/obj/item/stack/tile,
-		/obj/item/vending_refill,
+		/obj/item/vending_refill, // OCULIS EDIT: added comma
 		// NOVA EDIT ADDITION END
-		/obj/item/airbag, // OCULIS ADDITION
+		/obj/item/airbag, // OCULIS EDIT ADDITION
 	)
 
 /obj/item/borg/apparatus/engineering/Initialize(mapload)

--- a/code/game/objects/items/robot/items/storage.dm
+++ b/code/game/objects/items/robot/items/storage.dm
@@ -302,6 +302,7 @@
 		/obj/item/stack/tile,
 		/obj/item/vending_refill
 		// NOVA EDIT ADDITION END
+		/obj/item/airbag // OCULIS ADDITION
 	)
 
 /obj/item/borg/apparatus/engineering/Initialize(mapload)

--- a/code/game/objects/items/robot/items/storage.dm
+++ b/code/game/objects/items/robot/items/storage.dm
@@ -302,7 +302,7 @@
 		/obj/item/stack/tile,
 		/obj/item/vending_refill,
 		// NOVA EDIT ADDITION END
-		/obj/item/airbag // OCULIS ADDITION
+		/obj/item/airbag, // OCULIS ADDITION
 	)
 
 /obj/item/borg/apparatus/engineering/Initialize(mapload)


### PR DESCRIPTION

## About The Pull Request
Adds airbags to the list of allowed items for the cyborg engineering apparatus to pick up.

## Why it's Good for the Game
Lets cyborgs actually put airbags back in windows.

## Proof of Testing
Trivial change, haven't tested, can test if requested.
<!-- Include any screenshots/videos/debugging steps of the code functioning successfully-->

## Changelog

:cl:
add: Cyborg engineering apparatuses can now pick up airbags.
/:cl:

