### PR TITLE
Adds gas miners to both derelict drone stations

### DIFF
--- a/_maps/RandomRuins/SpaceRuins/nova/drones_derelict.dmm
+++ b/_maps/RandomRuins/SpaceRuins/nova/drones_derelict.dmm
@@ -32,6 +32,14 @@
 /obj/item/stack/cable_coil/cut,
 /turf/open/floor/iron/airless,
 /area/ruin/space/bb13/medical)
+"aB" = (
+/obj/effect/mapping_helpers/burnt_floor,
+/obj/structure/frame/computer{
+	anchored = 1;
+	dir = 8
+	},
+/turf/open/floor/plating/airless,
+/area/ruin/space/bb13/engineering/atmos)
 "aE" = (
 /obj/machinery/atmospherics/pipe/smart/simple/scrubbers/visible{
 	dir = 4
@@ -154,6 +162,10 @@
 /obj/structure/window/reinforced/spawner/directional/south,
 /turf/open/floor/iron/airless,
 /area/ruin/space/bb13/medical/genetics)
+"cC" = (
+/obj/machinery/atmospherics/components/unary/vent_pump/siphon/monitored,
+/turf/open/floor/engine/n2,
+/area/ruin/space/bb13/engineering/atmos)
 "cJ" = (
 /obj/effect/mapping_helpers/broken_floor,
 /turf/open/floor/plating/airless,
@@ -196,6 +208,10 @@
 /obj/item/clothing/head/helmet/space/eva,
 /turf/open/floor/plating/airless,
 /area/ruin/space/bb13/engineering/n_solars_control)
+"dP" = (
+/obj/machinery/atmospherics/miner/oxygen,
+/turf/open/floor/engine/o2,
+/area/ruin/space/bb13/engineering/atmos)
 "dT" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/iron/airless,
@@ -206,6 +222,11 @@
 	},
 /turf/open/floor/plating/airless,
 /area/ruin/space/bb13/bridge)
+"dW" = (
+/obj/effect/mapping_helpers/burnt_floor,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/cyan/visible,
+/turf/open/floor/iron/airless,
+/area/ruin/space/bb13/engineering/atmos)
 "dY" = (
 /turf/open/floor/iron/airless,
 /area/ruin/space/bb13/service/botany)
@@ -332,15 +353,21 @@
 /obj/structure/girder,
 /turf/open/floor/plating/airless,
 /area/ruin/space/bb13/service/botany)
+"gz" = (
+/obj/machinery/atmospherics/components/unary/vent_pump/siphon/monitored{
+	dir = 8
+	},
+/turf/open/floor/engine/plasma,
+/area/ruin/space/bb13/engineering/atmos)
 "gB" = (
 /obj/structure/grille/broken,
 /obj/item/shard,
 /turf/open/floor/plating/airless,
 /area/ruin/space/bb13/bridge)
 "gF" = (
-/obj/structure/lattice,
-/obj/item/stack/cable_coil/five,
-/turf/template_noop,
+/obj/effect/mapping_helpers/burnt_floor,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/cyan/visible,
+/turf/open/floor/plating/airless,
 /area/ruin/space/bb13/engineering/atmos)
 "gK" = (
 /obj/structure/chair{
@@ -413,6 +440,15 @@
 /obj/machinery/door/window/right/directional/west,
 /turf/open/floor/plating/airless,
 /area/ruin/space/bb13/service/botany)
+"hY" = (
+/obj/structure/grille/broken,
+/obj/item/shard/plasma,
+/obj/item/shard/plasma,
+/obj/machinery/atmospherics/pipe/layer_manifold/general{
+	dir = 4
+	},
+/turf/open/floor/plating/airless,
+/area/ruin/space/bb13/engineering/atmos)
 "hZ" = (
 /turf/open/floor/plating/airless,
 /area/ruin/space/bb13/engineering/engine)
@@ -467,6 +503,10 @@
 	},
 /turf/open/floor/iron/airless,
 /area/ruin/space/bb13/medical)
+"iw" = (
+/obj/machinery/atmospherics/components/unary/outlet_injector,
+/turf/open/floor/engine/o2,
+/area/ruin/space/bb13/engineering/atmos)
 "iz" = (
 /obj/structure/frame/machine,
 /obj/structure/lattice,
@@ -561,6 +601,14 @@
 	dir = 8
 	},
 /turf/open/floor/engine/airless,
+/area/ruin/space/bb13/engineering/atmos)
+"jh" = (
+/obj/effect/mapping_helpers/broken_floor,
+/obj/structure/frame/computer{
+	anchored = 1;
+	dir = 1
+	},
+/turf/open/floor/iron/airless,
 /area/ruin/space/bb13/engineering/atmos)
 "jj" = (
 /obj/structure/table,
@@ -788,6 +836,14 @@
 /obj/structure/cable,
 /turf/open/floor/plating/airless,
 /area/ruin/space/bb13/research/toxins)
+"ne" = (
+/obj/effect/mapping_helpers/burnt_floor,
+/obj/structure/frame/computer{
+	anchored = 1;
+	dir = 1
+	},
+/turf/open/floor/plating/airless,
+/area/ruin/space/bb13/engineering/atmos)
 "ni" = (
 /obj/machinery/door/airlock/external/glass,
 /obj/effect/mapping_helpers/broken_floor,
@@ -939,6 +995,12 @@
 /obj/structure/table_frame,
 /turf/open/floor/iron/airless,
 /area/ruin/space/bb13/research/toxins)
+"pG" = (
+/obj/machinery/air_sensor{
+	chamber_id = "babylon-air"
+	},
+/turf/open/floor/engine/air,
+/area/ruin/space/bb13/engineering/atmos)
 "pI" = (
 /obj/structure/lattice,
 /obj/structure/girder/reinforced,
@@ -1095,6 +1157,13 @@
 /obj/effect/mapping_helpers/broken_floor,
 /turf/open/floor/iron/airless,
 /area/ruin/space/bb13/medical/genetics)
+"rx" = (
+/obj/effect/mapping_helpers/broken_floor,
+/obj/machinery/computer/atmos_control/noreconnect{
+	atmos_chambers = list("babylon-air"="Air Supply")
+	},
+/turf/open/floor/plating/airless,
+/area/ruin/space/bb13/engineering/atmos)
 "ry" = (
 /obj/machinery/power/emitter{
 	dir = 4
@@ -1111,8 +1180,8 @@
 /turf/open/floor/iron/airless,
 /area/ruin/space/bb13/medical/genetics)
 "rE" = (
-/obj/machinery/atmospherics/components/unary/vent_pump,
-/turf/open/floor/engine/airless,
+/obj/machinery/atmospherics/components/unary/vent_pump/siphon/monitored,
+/turf/open/floor/engine/o2,
 /area/ruin/space/bb13/engineering/atmos)
 "rF" = (
 /obj/structure/closet/crate/bin,
@@ -1214,6 +1283,18 @@
 /obj/structure/cable,
 /turf/open/floor/plating/airless,
 /area/ruin/space/bb13/engineering/s_solars_control)
+"td" = (
+/obj/machinery/atmospherics/components/unary/outlet_injector{
+	dir = 8
+	},
+/turf/open/floor/engine/plasma,
+/area/ruin/space/bb13/engineering/atmos)
+"th" = (
+/obj/machinery/air_sensor{
+	chamber_id = "babylon-plasma"
+	},
+/turf/open/floor/engine/plasma,
+/area/ruin/space/bb13/engineering/atmos)
 "tj" = (
 /obj/structure/frame/computer{
 	anchored = 1;
@@ -1221,6 +1302,10 @@
 	},
 /turf/open/floor/iron/airless,
 /area/ruin/space/bb13/medical/genetics)
+"tu" = (
+/obj/machinery/atmospherics/miner/plasma,
+/turf/open/floor/engine/plasma,
+/area/ruin/space/bb13/engineering/atmos)
 "tw" = (
 /obj/machinery/portable_atmospherics/pump,
 /turf/open/floor/iron/airless,
@@ -1486,6 +1571,13 @@
 /obj/structure/door_assembly,
 /turf/open/floor/iron/airless,
 /area/ruin/space/bb13/service)
+"xH" = (
+/obj/effect/spawner/structure/window/reinforced/plasma,
+/obj/machinery/atmospherics/pipe/layer_manifold/general{
+	dir = 4
+	},
+/turf/open/floor/plating/airless,
+/area/ruin/space/bb13/engineering/atmos)
 "xI" = (
 /obj/effect/mapping_helpers/broken_floor,
 /obj/structure/cable,
@@ -1520,6 +1612,7 @@
 /area/ruin/space/bb13/engineering/engine)
 "yh" = (
 /obj/effect/spawner/structure/window/reinforced/plasma,
+/obj/machinery/atmospherics/pipe/layer_manifold/general,
 /turf/open/floor/plating/airless,
 /area/ruin/space/bb13/engineering/atmos)
 "yv" = (
@@ -1699,6 +1792,12 @@
 /obj/structure/reagent_dispensers/watertank,
 /turf/open/floor/plating/airless,
 /area/ruin/space/bb13/hallway)
+"Bb" = (
+/obj/machinery/air_sensor{
+	chamber_id = "babylon-n2"
+	},
+/turf/open/floor/engine/n2,
+/area/ruin/space/bb13/engineering/atmos)
 "Bc" = (
 /obj/structure/chair{
 	dir = 4
@@ -1744,10 +1843,20 @@
 /obj/item/stack/cable_coil,
 /turf/open/floor/iron/airless,
 /area/ruin/space/bb13/hallway/central)
+"Bz" = (
+/turf/open/floor/engine/air,
+/area/ruin/space/bb13/engineering/atmos)
 "BB" = (
 /obj/structure/cable,
 /turf/open/floor/iron/airless,
 /area/ruin/space/bb13/engineering/vault)
+"BO" = (
+/obj/effect/mapping_helpers/burnt_floor,
+/obj/machinery/computer/atmos_control/noreconnect{
+	atmos_chambers = list("babylon-n2"="Nitrogen Supply")
+	},
+/turf/open/floor/plating/airless,
+/area/ruin/space/bb13/engineering/atmos)
 "BP" = (
 /obj/machinery/power/energy_accumulator/grounding_rod/anchored,
 /obj/effect/mapping_helpers/broken_floor,
@@ -1923,6 +2032,10 @@
 /obj/structure/chair/stool/directional/west,
 /turf/open/floor/iron/airless,
 /area/ruin/space/bb13/service)
+"Fo" = (
+/obj/machinery/atmospherics/components/unary/outlet_injector,
+/turf/open/floor/engine/air,
+/area/ruin/space/bb13/engineering/atmos)
 "Fs" = (
 /obj/structure/chair{
 	dir = 8
@@ -1942,6 +2055,11 @@
 /obj/machinery/light/small/directional/west,
 /turf/open/floor/iron/airless,
 /area/ruin/space/bb13/research)
+"FC" = (
+/obj/effect/mapping_helpers/broken_floor,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/cyan/visible,
+/turf/open/floor/iron/airless,
+/area/ruin/space/bb13/engineering/atmos)
 "FJ" = (
 /obj/machinery/door/airlock/engineering,
 /obj/effect/mapping_helpers/broken_floor,
@@ -1973,9 +2091,8 @@
 /turf/open/floor/plating/airless,
 /area/ruin/space/bb13/hallway)
 "FY" = (
-/obj/structure/lattice,
-/obj/machinery/atmospherics/components/unary/vent_pump,
-/turf/template_noop,
+/obj/machinery/atmospherics/components/unary/vent_pump/siphon/monitored,
+/turf/open/floor/engine/air,
 /area/ruin/space/bb13/engineering/atmos)
 "Gm" = (
 /obj/item/kirbyplants/random/dead,
@@ -2327,6 +2444,7 @@
 /obj/structure/grille/broken,
 /obj/item/shard/plasma,
 /obj/item/shard/plasma,
+/obj/machinery/atmospherics/pipe/layer_manifold/general,
 /turf/open/floor/plating/airless,
 /area/ruin/space/bb13/engineering/atmos)
 "Mh" = (
@@ -2369,6 +2487,13 @@
 "ME" = (
 /turf/open/floor/plating/airless,
 /area/ruin/space/bb13/research/toxins)
+"MN" = (
+/obj/effect/mapping_helpers/broken_floor,
+/obj/machinery/computer/atmos_control/noreconnect{
+	atmos_chambers = list("babylon-o2"="Oxygen Supply")
+	},
+/turf/open/floor/iron/airless,
+/area/ruin/space/bb13/engineering/atmos)
 "MO" = (
 /obj/structure/cable,
 /turf/open/floor/iron/airless,
@@ -2470,6 +2595,10 @@
 "Oj" = (
 /turf/open/floor/plating/airless,
 /area/ruin/space/bb13/engineering/n_solars_control)
+"Om" = (
+/obj/item/stack/cable_coil/five,
+/turf/template_noop,
+/area/template_noop)
 "Op" = (
 /obj/machinery/power/port_gen/pacman,
 /turf/open/floor/iron/airless,
@@ -2564,6 +2693,7 @@
 "PQ" = (
 /obj/structure/grille/broken,
 /obj/item/shard/plasma,
+/obj/machinery/atmospherics/pipe/layer_manifold/general,
 /turf/open/floor/plating/airless,
 /area/ruin/space/bb13/engineering/atmos)
 "PV" = (
@@ -2595,6 +2725,10 @@
 /obj/item/stack/cable_coil/cut,
 /turf/template_noop,
 /area/ruin/space/bb13/research)
+"Qm" = (
+/obj/machinery/atmospherics/miner/nitrogen,
+/turf/open/floor/engine/n2,
+/area/ruin/space/bb13/engineering/atmos)
 "Qu" = (
 /turf/open/floor/iron/dark/airless,
 /area/ruin/space/bb13/medical)
@@ -2625,6 +2759,13 @@
 /obj/effect/mapping_helpers/broken_floor,
 /obj/machinery/light/small/directional/east,
 /turf/open/floor/plating/airless,
+/area/ruin/space/bb13/engineering/atmos)
+"QW" = (
+/obj/effect/mapping_helpers/burnt_floor,
+/obj/machinery/atmospherics/components/trinary/mixer/airmix/flipped{
+	dir = 8
+	},
+/turf/open/floor/iron/airless,
 /area/ruin/space/bb13/engineering/atmos)
 "Rg" = (
 /obj/structure/closet/crate/bin,
@@ -2713,7 +2854,7 @@
 /area/ruin/space/bb13/hallway/central)
 "SD" = (
 /obj/machinery/atmospherics/components/unary/outlet_injector,
-/turf/open/floor/engine/airless,
+/turf/open/floor/engine/n2,
 /area/ruin/space/bb13/engineering/atmos)
 "SE" = (
 /turf/closed/wall,
@@ -2914,6 +3055,14 @@
 "Ve" = (
 /turf/template_noop,
 /area/ruin/space/bb13/security)
+"Vh" = (
+/obj/effect/mapping_helpers/broken_floor,
+/obj/machinery/computer/atmos_control/noreconnect{
+	atmos_chambers = list("babylon-plasma"="Plasma Supply");
+	dir = 8
+	},
+/turf/open/floor/plating/airless,
+/area/ruin/space/bb13/engineering/atmos)
 "Vs" = (
 /obj/effect/mapping_helpers/burnt_floor,
 /obj/machinery/light/small/directional/east,
@@ -2948,6 +3097,12 @@
 /obj/effect/spawner/random/maintenance,
 /turf/open/floor/iron/airless,
 /area/ruin/space/bb13/bridge)
+"VW" = (
+/obj/machinery/air_sensor{
+	chamber_id = "babylon-o2"
+	},
+/turf/open/floor/engine/o2,
+/area/ruin/space/bb13/engineering/atmos)
 "Wa" = (
 /obj/structure/lattice,
 /obj/item/shard/plasma,
@@ -7413,11 +7568,11 @@ fE
 jA
 yZ
 yZ
-aj
-ZW
+Ks
+Qm
 SD
 yh
-nq
+BO
 nq
 sI
 sI
@@ -7497,11 +7652,11 @@ jA
 yZ
 yZ
 Ks
-hc
-FY
+Bb
+cC
 yh
-nq
-nq
+gF
+gF
 sI
 ZW
 sI
@@ -7510,7 +7665,7 @@ nq
 nq
 ug
 bQ
-nq
+ne
 PQ
 Vb
 hc
@@ -7580,12 +7735,12 @@ jA
 yZ
 yZ
 Ks
-ZW
-ZW
-ZW
+Ks
+Ks
+Ks
 nq
 nq
-nq
+gF
 nq
 nq
 ZW
@@ -7663,12 +7818,12 @@ jA
 yZ
 yZ
 Ks
-hc
-SD
+dP
+iw
 yh
+MN
 ug
-ug
-sI
+dW
 sI
 BW
 sI
@@ -7745,13 +7900,13 @@ fE
 jA
 yZ
 yZ
-aj
-ZW
+Ks
+VW
 rE
 yh
+FC
 ug
-ug
-bQ
+QW
 ZW
 sI
 nq
@@ -7759,7 +7914,7 @@ Ml
 Ml
 CP
 ug
-ug
+jh
 yh
 Vb
 hc
@@ -7829,12 +7984,12 @@ Oj
 yZ
 yZ
 Ks
-mf
+Ks
 Ks
 Ks
 ug
 ug
-sI
+dW
 sI
 bQ
 nq
@@ -7910,12 +8065,12 @@ Oj
 fE
 Oj
 HZ
-yZ
-gF
-ZW
-SD
+Om
+Ks
+Bz
+Fo
 yh
-Ml
+rx
 UD
 Ml
 ug
@@ -7995,7 +8150,7 @@ jA
 yZ
 Zd
 Ks
-hc
+pG
 FY
 yh
 Ml
@@ -8008,7 +8163,7 @@ ug
 ug
 bQ
 ZW
-nq
+ne
 yh
 CM
 ZW
@@ -8083,12 +8238,12 @@ Ks
 Ks
 ug
 Ml
-Ml
+Vh
 Ml
 QS
 nq
 nq
-nq
+aB
 sI
 uC
 sI
@@ -8166,13 +8321,13 @@ Za
 XR
 EM
 Ks
-yh
-yh
+xH
+xH
 Ks
 sI
 mf
-Mc
-yh
+hY
+xH
 aj
 bQ
 bQ
@@ -8249,9 +8404,9 @@ fW
 dB
 iM
 Ks
-Zw
-jg
-mf
+td
+gz
+Ks
 uo
 Ks
 Zw
@@ -8332,9 +8487,9 @@ EM
 vj
 cc
 Ks
-ZW
-hc
-mf
+tu
+th
+Ks
 fj
 mf
 hc
@@ -8414,8 +8569,8 @@ Wg
 AK
 jv
 ds
-aj
-aj
+Ks
+Ks
 Ks
 Ks
 uo

--- a/_maps/RandomRuins/SpaceRuins/nova/drones_derelict.dmm
+++ b/_maps/RandomRuins/SpaceRuins/nova/drones_derelict.dmm
@@ -2614,10 +2614,6 @@
 "Oj" = (
 /turf/open/floor/plating/airless,
 /area/ruin/space/bb13/engineering/n_solars_control)
-"Om" = (
-/obj/item/stack/cable_coil/five,
-/turf/template_noop,
-/area/template_noop)
 "Op" = (
 /obj/machinery/power/port_gen/pacman,
 /turf/open/floor/iron/airless,
@@ -8089,8 +8085,8 @@ yZ
 Oj
 fE
 Oj
-HZ
-Om
+VT
+yZ
 Ks
 Bz
 Fo

--- a/_maps/RandomRuins/SpaceRuins/nova/drones_derelict.dmm
+++ b/_maps/RandomRuins/SpaceRuins/nova/drones_derelict.dmm
@@ -21,6 +21,11 @@
 /obj/structure/girder,
 /turf/template_noop,
 /area/ruin/space/bb13/engineering/s_solars_control)
+"aq" = (
+/obj/effect/spawner/structure/window/reinforced/plasma,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/visible,
+/turf/open/floor/plating/airless,
+/area/ruin/space/bb13/engineering/atmos)
 "ar" = (
 /obj/structure/chair{
 	dir = 4
@@ -38,6 +43,7 @@
 	anchored = 1;
 	dir = 8
 	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/visible,
 /turf/open/floor/plating/airless,
 /area/ruin/space/bb13/engineering/atmos)
 "aE" = (
@@ -444,9 +450,7 @@
 /obj/structure/grille/broken,
 /obj/item/shard/plasma,
 /obj/item/shard/plasma,
-/obj/machinery/atmospherics/pipe/layer_manifold/general{
-	dir = 4
-	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/visible,
 /turf/open/floor/plating/airless,
 /area/ruin/space/bb13/engineering/atmos)
 "hZ" = (
@@ -504,7 +508,7 @@
 /turf/open/floor/iron/airless,
 /area/ruin/space/bb13/medical)
 "iw" = (
-/obj/machinery/atmospherics/components/unary/outlet_injector,
+/obj/machinery/atmospherics/components/unary/outlet_injector/monitored,
 /turf/open/floor/engine/o2,
 /area/ruin/space/bb13/engineering/atmos)
 "iz" = (
@@ -608,6 +612,7 @@
 	anchored = 1;
 	dir = 1
 	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/visible,
 /turf/open/floor/iron/airless,
 /area/ruin/space/bb13/engineering/atmos)
 "jj" = (
@@ -700,6 +705,11 @@
 /obj/structure/table_frame,
 /turf/open/floor/iron/airless,
 /area/ruin/space/bb13/service)
+"kq" = (
+/obj/effect/spawner/structure/window/reinforced/plasma,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/cyan/visible,
+/turf/open/floor/plating/airless,
+/area/ruin/space/bb13/engineering/atmos)
 "ku" = (
 /obj/machinery/light/small/directional/north,
 /turf/open/floor/iron/airless,
@@ -842,6 +852,7 @@
 	anchored = 1;
 	dir = 1
 	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/visible,
 /turf/open/floor/plating/airless,
 /area/ruin/space/bb13/engineering/atmos)
 "ni" = (
@@ -1162,6 +1173,7 @@
 /obj/machinery/computer/atmos_control/noreconnect{
 	atmos_chambers = list("babylon-air"="Air Supply")
 	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/cyan/visible,
 /turf/open/floor/plating/airless,
 /area/ruin/space/bb13/engineering/atmos)
 "ry" = (
@@ -1284,7 +1296,7 @@
 /turf/open/floor/plating/airless,
 /area/ruin/space/bb13/engineering/s_solars_control)
 "td" = (
-/obj/machinery/atmospherics/components/unary/outlet_injector{
+/obj/machinery/atmospherics/components/unary/outlet_injector/monitored{
 	dir = 8
 	},
 /turf/open/floor/engine/plasma,
@@ -1855,6 +1867,7 @@
 /obj/machinery/computer/atmos_control/noreconnect{
 	atmos_chambers = list("babylon-n2"="Nitrogen Supply")
 	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/visible,
 /turf/open/floor/plating/airless,
 /area/ruin/space/bb13/engineering/atmos)
 "BP" = (
@@ -2033,7 +2046,7 @@
 /turf/open/floor/iron/airless,
 /area/ruin/space/bb13/service)
 "Fo" = (
-/obj/machinery/atmospherics/components/unary/outlet_injector,
+/obj/machinery/atmospherics/components/unary/outlet_injector/monitored,
 /turf/open/floor/engine/air,
 /area/ruin/space/bb13/engineering/atmos)
 "Fs" = (
@@ -2284,6 +2297,11 @@
 /obj/structure/table_frame,
 /turf/template_noop,
 /area/ruin/space/bb13/medical)
+"Jb" = (
+/obj/effect/mapping_helpers/broken_floor,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/orange/visible,
+/turf/open/floor/plating/airless,
+/area/ruin/space/bb13/engineering/atmos)
 "Jd" = (
 /obj/structure/window/reinforced/spawner/directional/south,
 /obj/effect/mapping_helpers/broken_floor,
@@ -2492,6 +2510,7 @@
 /obj/machinery/computer/atmos_control/noreconnect{
 	atmos_chambers = list("babylon-o2"="Oxygen Supply")
 	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/visible,
 /turf/open/floor/iron/airless,
 /area/ruin/space/bb13/engineering/atmos)
 "MO" = (
@@ -2693,7 +2712,7 @@
 "PQ" = (
 /obj/structure/grille/broken,
 /obj/item/shard/plasma,
-/obj/machinery/atmospherics/pipe/layer_manifold/general,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/visible,
 /turf/open/floor/plating/airless,
 /area/ruin/space/bb13/engineering/atmos)
 "PV" = (
@@ -2852,8 +2871,13 @@
 /obj/machinery/light/small/directional/south,
 /turf/open/floor/plating/airless,
 /area/ruin/space/bb13/hallway/central)
+"SA" = (
+/obj/effect/mapping_helpers/broken_floor,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/visible/layer4,
+/turf/open/floor/plating/airless,
+/area/ruin/space/bb13/engineering/atmos)
 "SD" = (
-/obj/machinery/atmospherics/components/unary/outlet_injector,
+/obj/machinery/atmospherics/components/unary/outlet_injector/monitored,
 /turf/open/floor/engine/n2,
 /area/ruin/space/bb13/engineering/atmos)
 "SE" = (
@@ -3061,6 +3085,7 @@
 	atmos_chambers = list("babylon-plasma"="Plasma Supply");
 	dir = 8
 	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/visible,
 /turf/open/floor/plating/airless,
 /area/ruin/space/bb13/engineering/atmos)
 "Vs" = (
@@ -7571,7 +7596,7 @@ yZ
 Ks
 Qm
 SD
-yh
+aq
 BO
 nq
 sI
@@ -7740,7 +7765,7 @@ Ks
 Ks
 nq
 nq
-gF
+nq
 nq
 nq
 ZW
@@ -7820,7 +7845,7 @@ yZ
 Ks
 dP
 iw
-yh
+aq
 MN
 ug
 dW
@@ -7915,7 +7940,7 @@ Ml
 CP
 ug
 jh
-yh
+aq
 Vb
 hc
 ZW
@@ -7989,7 +8014,7 @@ Ks
 Ks
 ug
 ug
-dW
+sI
 sI
 bQ
 nq
@@ -8069,7 +8094,7 @@ Om
 Ks
 Bz
 Fo
-yh
+kq
 rx
 UD
 Ml
@@ -8153,10 +8178,10 @@ Ks
 pG
 FY
 yh
+SA
 Ml
 Ml
-Ml
-Ml
+Jb
 Ml
 sI
 ug
@@ -8164,7 +8189,7 @@ ug
 bQ
 ZW
 ne
-yh
+aq
 CM
 ZW
 Ks
@@ -8239,7 +8264,7 @@ Ks
 ug
 Ml
 Vh
-Ml
+Jb
 QS
 nq
 nq
@@ -8321,7 +8346,7 @@ Za
 XR
 EM
 Ks
-xH
+aq
 xH
 Ks
 sI

--- a/_maps/RandomRuins/SpaceRuins/russian_derelict.dmm
+++ b/_maps/RandomRuins/SpaceRuins/russian_derelict.dmm
@@ -5583,6 +5583,10 @@
 	pixel_x = -6;
 	pixel_y = 6
 	},
+/obj/item/circuitboard/machine/bluespace_miner{
+	pixel_x = -3;
+	pixel_y = 3
+	},
 /obj/item/circuitboard/machine/protolathe/offstation,
 /turf/open/floor/circuit/red/off,
 /area/ruin/space/ks13/ai/corridor)

--- a/_maps/RandomRuins/SpaceRuins/russian_derelict.dmm
+++ b/_maps/RandomRuins/SpaceRuins/russian_derelict.dmm
@@ -577,12 +577,6 @@
 "fO" = (
 /turf/open/floor/iron/airless,
 /area/ruin/space/ks13/service/cafe)
-"fQ" = (
-/obj/effect/spawner/structure/window/hollow/reinforced/end{
-	dir = 4
-	},
-/turf/open/floor/plating/airless,
-/area/ruin/space/ks13/engineering/atmos)
 "fU" = (
 /turf/open/floor/iron,
 /area/ruin/space/ks13/ai/corridor)
@@ -665,8 +659,8 @@
 /turf/open/floor/plating/airless,
 /area/ruin/space/ks13/engineering/aft_solars_control)
 "hQ" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/visible,
-/obj/effect/spawner/structure/window/hollow/reinforced/middle,
+/obj/effect/mapping_helpers/burnt_floor,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/cyan/visible,
 /turf/open/floor/plating/airless,
 /area/ruin/space/ks13/engineering/atmos)
 "hT" = (
@@ -1006,7 +1000,8 @@
 /turf/open/floor/plating/airless,
 /area/ruin/space/ks13/engineering/aux_storage)
 "mb" = (
-/turf/open/floor/engine/airless,
+/obj/machinery/atmospherics/miner/nitrogen,
+/turf/open/floor/engine/n2,
 /area/ruin/space/ks13/engineering/atmos)
 "mc" = (
 /obj/effect/mapping_helpers/broken_floor,
@@ -1348,9 +1343,6 @@
 /area/ruin/space/ks13/science/rnd)
 "pm" = (
 /obj/machinery/light/small/directional/west,
-/obj/machinery/atmospherics/pipe/smart/simple/cyan/visible{
-	dir = 6
-	},
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/power/apc/auto_name/directional/west,
 /obj/effect/mapping_helpers/apc/no_charge,
@@ -1807,9 +1799,7 @@
 /area/ruin/space/ks13/science/ordnance_hall)
 "rN" = (
 /obj/machinery/atmospherics/components/unary/outlet_injector/monitored,
-/turf/open/floor/engine/air{
-	initial_gas_mix = "o2=20000;n2=80000;TEMP=293.15"
-	},
+/turf/open/floor/engine/o2,
 /area/ruin/space/ks13/engineering/atmos)
 "rO" = (
 /obj/effect/turf_decal/plaque{
@@ -2300,8 +2290,8 @@
 /turf/open/floor/iron/white/airless,
 /area/ruin/space/ks13/medical/medbay)
 "um" = (
-/obj/effect/decal/cleanable/glass,
-/obj/effect/decal/cleanable/dirt,
+/obj/effect/spawner/structure/window/hollow/reinforced/middle,
+/obj/machinery/atmospherics/pipe/layer_manifold/general,
 /turf/open/floor/plating/airless,
 /area/ruin/space/ks13/engineering/atmos)
 "un" = (
@@ -2425,11 +2415,6 @@
 /obj/structure/cable,
 /turf/open/floor/iron/airless,
 /area/ruin/space/ks13/dorms)
-"ve" = (
-/obj/effect/spawner/structure/window/hollow/reinforced/middle,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/visible,
-/turf/open/floor/plating/airless,
-/area/ruin/space/ks13/engineering/atmos)
 "vi" = (
 /obj/effect/mapping_helpers/burnt_floor,
 /turf/open/floor/plating/airless,
@@ -2690,9 +2675,10 @@
 /turf/open/floor/iron/white/airless,
 /area/ruin/space/ks13/medical/medbay)
 "wG" = (
-/obj/structure/table_frame,
-/obj/effect/spawner/random/engineering/flashlight{
-	pixel_y = 5
+/obj/effect/mapping_helpers/broken_floor,
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/atmospherics/components/trinary/mixer/airmix/flipped{
+	dir = 8
 	},
 /turf/open/floor/plating/airless,
 /area/ruin/space/ks13/engineering/atmos)
@@ -2700,8 +2686,8 @@
 /turf/closed/wall,
 /area/ruin/space/ks13/service/jani)
 "wI" = (
-/obj/machinery/atmospherics/pipe/smart/simple/cyan/visible,
 /obj/effect/mapping_helpers/broken_floor,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/cyan/visible,
 /turf/open/floor/plating/airless,
 /area/ruin/space/ks13/engineering/atmos)
 "wJ" = (
@@ -2825,11 +2811,11 @@
 /turf/open/floor/iron/white/airless,
 /area/ruin/space/ks13/medical/medbay)
 "xo" = (
-/obj/machinery/atmospherics/components/unary/vent_pump/on{
-	dir = 8
-	},
 /obj/effect/mapping_helpers/broken_floor,
 /obj/effect/decal/cleanable/dirt,
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
+	dir = 8
+	},
 /turf/open/floor/plating/airless,
 /area/ruin/space/ks13/engineering/atmos)
 "xp" = (
@@ -3223,15 +3209,10 @@
 /turf/open/floor/plating/airless,
 /area/ruin/space/ks13/hallway/central)
 "zk" = (
-/obj/item/shard{
-	icon_state = "small";
-	pixel_x = 6;
-	pixel_y = -4
-	},
-/obj/machinery/atmospherics/components/unary/portables_connector/visible{
+/obj/machinery/atmospherics/components/unary/vent_pump/siphon/monitored{
 	dir = 1
 	},
-/turf/open/floor/iron/airless,
+/turf/open/floor/engine/plasma,
 /area/ruin/space/ks13/engineering/atmos)
 "zm" = (
 /obj/machinery/door/airlock/external/ruin{
@@ -3333,9 +3314,10 @@
 /turf/open/floor/iron/airless,
 /area/space/nearstation)
 "zO" = (
-/obj/effect/spawner/structure/window/hollow/reinforced/middle,
-/obj/machinery/atmospherics/pipe/smart/simple/cyan/visible,
-/turf/open/floor/plating/airless,
+/obj/machinery/air_sensor{
+	chamber_id = "ks13-3"
+	},
+/turf/open/floor/engine/plasma,
 /area/ruin/space/ks13/engineering/atmos)
 "zP" = (
 /obj/effect/mapping_helpers/burnt_floor,
@@ -3392,6 +3374,17 @@
 /obj/machinery/light/small/directional/south,
 /obj/structure/table_frame,
 /obj/effect/spawner/random/engineering/tool,
+/obj/effect/spawner/random/engineering/flashlight{
+	pixel_y = 5
+	},
+/obj/effect/spawner/random/maintenance,
+/obj/item/wallframe/airalarm{
+	pixel_y = 5
+	},
+/obj/item/wallframe/airalarm,
+/obj/item/wallframe/airalarm{
+	pixel_y = -5
+	},
 /turf/open/floor/iron/airless,
 /area/ruin/space/ks13/engineering/atmos)
 "Ag" = (
@@ -3480,10 +3473,10 @@
 /turf/open/floor/iron/airless,
 /area/ruin/space/ks13/science/rnd)
 "Az" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/visible,
 /obj/machinery/computer/atmos_control/noreconnect{
-	atmos_chambers = list("ks13"="Primary Air Supply")
+	atmos_chambers = list("ks13"="Oxygen Supply")
 	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/cyan/visible,
 /turf/open/floor/plating/airless,
 /area/ruin/space/ks13/engineering/atmos)
 "AC" = (
@@ -3587,9 +3580,9 @@
 /turf/open/floor/plating,
 /area/ruin/space/ks13/medical/morgue)
 "AZ" = (
-/obj/structure/table_frame,
-/obj/effect/spawner/random/maintenance,
-/turf/open/floor/plating/airless,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/iron/airless,
 /area/ruin/space/ks13/engineering/atmos)
 "Bb" = (
 /obj/effect/decal/cleanable/glass,
@@ -3845,10 +3838,10 @@
 /turf/closed/wall/r_wall,
 /area/ruin/space/ks13/science/rnd)
 "CC" = (
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on{
+/obj/effect/mapping_helpers/burnt_floor,
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
 	dir = 4
 	},
-/obj/effect/mapping_helpers/burnt_floor,
 /turf/open/floor/plating/airless,
 /area/ruin/space/ks13/engineering/atmos)
 "CH" = (
@@ -3860,7 +3853,7 @@
 /turf/open/floor/plating/airless,
 /area/ruin/space/ks13/engineering/supermatter)
 "CI" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/visible,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/cyan/visible,
 /turf/open/floor/plating/airless,
 /area/ruin/space/ks13/engineering/atmos)
 "CJ" = (
@@ -3956,12 +3949,12 @@
 /turf/open/floor/plating/airless,
 /area/space/nearstation)
 "Di" = (
-/obj/machinery/pipedispenser,
-/turf/open/floor/iron/airless,
+/obj/machinery/atmospherics/miner/plasma,
+/turf/open/floor/engine/plasma,
 /area/ruin/space/ks13/engineering/atmos)
 "Dl" = (
-/obj/machinery/atmospherics/pipe/smart/simple/cyan/visible,
-/obj/effect/mapping_helpers/burnt_floor,
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/atmospherics/components/tank/air,
 /turf/open/floor/plating/airless,
 /area/ruin/space/ks13/engineering/atmos)
 "Dm" = (
@@ -4187,7 +4180,7 @@
 /obj/machinery/air_sensor{
 	chamber_id = "ks13-2"
 	},
-/turf/open/floor/engine/airless,
+/turf/open/floor/engine/n2,
 /area/ruin/space/ks13/engineering/atmos)
 "Eq" = (
 /obj/structure/window/reinforced/spawner/directional/north,
@@ -4292,10 +4285,8 @@
 /turf/open/floor/iron/airless,
 /area/ruin/space/ks13/engineering/atmos)
 "EP" = (
-/obj/machinery/portable_atmospherics/canister/air,
-/turf/open/floor/engine/air{
-	initial_gas_mix = "o2=20000;n2=80000;TEMP=293.15"
-	},
+/obj/machinery/atmospherics/miner/oxygen,
+/turf/open/floor/engine/o2,
 /area/ruin/space/ks13/engineering/atmos)
 "EQ" = (
 /obj/structure/table,
@@ -4491,10 +4482,9 @@
 /turf/open/floor/iron/airless,
 /area/ruin/space/ks13/service/cafe)
 "FS" = (
-/obj/machinery/atmospherics/components/trinary/mixer/airmix/flipped/inverse,
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/cable,
-/turf/open/floor/plating/airless,
+/obj/effect/mapping_helpers/broken_floor,
+/obj/machinery/atmospherics/components/tank/air,
+/turf/open/floor/iron/airless,
 /area/ruin/space/ks13/engineering/atmos)
 "FT" = (
 /obj/structure/grille/broken,
@@ -4563,8 +4553,10 @@
 /turf/open/floor/plating/airless,
 /area/ruin/space/ks13/medical/medbay)
 "Gk" = (
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/iron/airless,
+/obj/machinery/atmospherics/components/unary/outlet_injector/monitored{
+	dir = 1
+	},
+/turf/open/floor/engine/plasma,
 /area/ruin/space/ks13/engineering/atmos)
 "Gl" = (
 /obj/effect/mapping_helpers/burnt_floor,
@@ -4663,9 +4655,7 @@
 /turf/open/floor/iron/airless,
 /area/ruin/space/ks13/service/bar)
 "GM" = (
-/obj/machinery/atmospherics/components/unary/portables_connector/visible{
-	dir = 1
-	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/orange/visible,
 /turf/open/floor/iron/airless,
 /area/ruin/space/ks13/engineering/atmos)
 "GN" = (
@@ -4913,7 +4903,7 @@
 /area/ruin/space/ks13/science/genetics)
 "HU" = (
 /obj/machinery/atmospherics/components/unary/outlet_injector/monitored,
-/turf/open/floor/engine/airless,
+/turf/open/floor/engine/n2,
 /area/ruin/space/ks13/engineering/atmos)
 "HV" = (
 /obj/effect/mapping_helpers/broken_floor,
@@ -5203,9 +5193,9 @@
 /turf/closed/wall,
 /area/ruin/space/ks13/service/kitchen)
 "JE" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/visible,
 /obj/effect/mapping_helpers/burnt_floor,
 /obj/effect/decal/cleanable/dirt,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/cyan/visible,
 /turf/open/floor/plating/airless,
 /area/ruin/space/ks13/engineering/atmos)
 "JF" = (
@@ -5857,9 +5847,7 @@
 /area/space/nearstation)
 "Nf" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/siphon/monitored,
-/turf/open/floor/engine/air{
-	initial_gas_mix = "o2=20000;n2=80000;TEMP=293.15"
-	},
+/turf/open/floor/engine/o2,
 /area/ruin/space/ks13/engineering/atmos)
 "Nh" = (
 /obj/structure/table,
@@ -6091,8 +6079,9 @@
 /turf/open/floor/iron,
 /area/ruin/space/ks13/hallway/starboard_bow)
 "Op" = (
-/obj/machinery/atmospherics/pipe/smart/simple/cyan/visible,
-/turf/open/floor/iron/airless,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/visible,
+/obj/machinery/pipedispenser,
+/turf/open/floor/plating/airless,
 /area/ruin/space/ks13/engineering/atmos)
 "Oq" = (
 /obj/effect/spawner/structure/window/hollow/reinforced/middle,
@@ -6497,7 +6486,7 @@
 /area/ruin/space/ks13/service/cafe)
 "Qq" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/siphon/monitored,
-/turf/open/floor/engine/airless,
+/turf/open/floor/engine/n2,
 /area/ruin/space/ks13/engineering/atmos)
 "Qr" = (
 /obj/structure/girder/reinforced,
@@ -6593,11 +6582,11 @@
 /turf/open/floor/plating,
 /area/ruin/space/ks13/service/chapel_office)
 "QY" = (
-/obj/structure/grille/broken,
-/obj/effect/decal/cleanable/glass,
-/obj/item/shard{
-	pixel_x = 5
+/obj/machinery/computer/atmos_control/noreconnect{
+	dir = 1;
+	atmos_chambers = list("ks13-3"="Plasma Supply")
 	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/orange/visible,
 /turf/open/floor/plating/airless,
 /area/ruin/space/ks13/engineering/atmos)
 "QZ" = (
@@ -6758,10 +6747,10 @@
 /area/ruin/space/ks13/science/genetics)
 "RO" = (
 /obj/machinery/computer/atmos_control/noreconnect{
-	atmos_chambers = list("ks13-2"="Secondary Chamber")
+	atmos_chambers = list("ks13-2"="Nitrogen Supply")
 	},
-/obj/machinery/atmospherics/pipe/smart/simple/cyan/visible,
 /obj/effect/decal/cleanable/dirt,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/visible,
 /turf/open/floor/plating/airless,
 /area/ruin/space/ks13/engineering/atmos)
 "RP" = (
@@ -6905,9 +6894,7 @@
 /obj/machinery/air_sensor{
 	chamber_id = "ks13"
 	},
-/turf/open/floor/engine/air{
-	initial_gas_mix = "o2=20000;n2=80000;TEMP=293.15"
-	},
+/turf/open/floor/engine/o2,
 /area/ruin/space/ks13/engineering/atmos)
 "Sz" = (
 /obj/effect/decal/cleanable/dirt,
@@ -7122,15 +7109,8 @@
 /turf/open/floor/iron/airless,
 /area/ruin/space/ks13/dorms)
 "Tl" = (
-/obj/structure/table,
-/obj/item/wallframe/airalarm{
-	pixel_y = 5
-	},
-/obj/item/wallframe/airalarm,
-/obj/item/wallframe/airalarm{
-	pixel_y = -5
-	},
-/turf/open/floor/plating/airless,
+/obj/effect/mapping_helpers/burnt_floor,
+/turf/open/floor/iron/airless,
 /area/ruin/space/ks13/engineering/atmos)
 "Tn" = (
 /obj/effect/spawner/structure/window/hollow/reinforced/end{
@@ -7492,6 +7472,7 @@
 "Ve" = (
 /obj/effect/mapping_helpers/broken_floor,
 /obj/effect/decal/cleanable/dirt,
+/obj/machinery/atmospherics/components/tank/air,
 /turf/open/floor/iron/airless,
 /area/ruin/space/ks13/engineering/atmos)
 "Vh" = (
@@ -12253,19 +12234,19 @@ pT
 tY
 mb
 Qq
-hQ
+um
 CI
 JE
 YP
 pm
-Op
+ON
 GM
 QY
 um
-YP
-vJ
-AZ
+zk
+Di
 tY
+aa
 aa
 ZK
 kk
@@ -12366,19 +12347,19 @@ pT
 tY
 Eo
 HU
-zO
+um
 RO
-Dl
+sl
 wI
-FS
-wI
-zk
-RY
-Di
+AS
+yA
+ON
+Op
+um
 Gk
-YP
-Tl
+zO
 tY
+aa
 aa
 ZK
 mv
@@ -12482,16 +12463,16 @@ tY
 tY
 DB
 RT
-sl
+hQ
 HD
 CC
-RT
-fQ
-ON
-YP
-Gk
-wG
-de
+sl
+sl
+tY
+tY
+tY
+tY
+tY
 tY
 od
 xk
@@ -12592,18 +12573,18 @@ Uw
 tY
 EP
 Nf
-hQ
+um
 Az
-CI
-Rg
+RT
+wG
 eM
 Re
 sl
+Tl
 un
 RT
 rj
-rj
-YP
+AZ
 vq
 Af
 od
@@ -12705,18 +12686,18 @@ Uw
 tY
 Sy
 rN
-ve
+um
 WI
 yA
-HJ
+JE
 FG
 FP
 RT
+ON
 Iv
 pJ
 EO
 vq
-YP
 bd
 Jl
 od
@@ -12824,10 +12805,10 @@ HJ
 UL
 AS
 Pd
+RT
 Hf
 LQ
 LQ
-re
 re
 re
 LQ
@@ -12939,8 +12920,8 @@ vC
 Xw
 TH
 Ih
-sl
 Ke
+YP
 YP
 YP
 JR
@@ -13052,9 +13033,9 @@ rj
 rS
 YP
 JH
-HJ
 Iv
-vq
+Dl
+FS
 YP
 eH
 eH
@@ -13165,8 +13146,8 @@ RT
 xo
 YP
 BF
-Ve
 RY
+Dl
 Ve
 vy
 tY
@@ -13278,8 +13259,8 @@ TE
 vJ
 RT
 Pd
-Ve
 RY
+Dl
 Ve
 Kv
 tY

--- a/_maps/RandomRuins/SpaceRuins/russian_derelict.dmm
+++ b/_maps/RandomRuins/SpaceRuins/russian_derelict.dmm
@@ -2686,8 +2686,8 @@
 /turf/closed/wall,
 /area/ruin/space/ks13/service/jani)
 "wI" = (
-/obj/effect/mapping_helpers/broken_floor,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/cyan/visible,
+/obj/effect/spawner/structure/window/hollow/reinforced/middle,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/visible,
 /turf/open/floor/plating/airless,
 /area/ruin/space/ks13/engineering/atmos)
 "wJ" = (
@@ -12133,7 +12133,7 @@ tY
 tY
 tY
 vk
-vk
+uO
 uO
 ZK
 wq
@@ -12236,7 +12236,7 @@ mb
 Qq
 um
 CI
-JE
+HJ
 YP
 pm
 ON
@@ -12347,15 +12347,15 @@ pT
 tY
 Eo
 HU
-um
+wI
 RO
 sl
-wI
+yA
 AS
 yA
 ON
 Op
-um
+wI
 Gk
 zO
 tY
@@ -12575,7 +12575,7 @@ EP
 Nf
 um
 Az
-RT
+CI
 wG
 eM
 Re
@@ -12686,7 +12686,7 @@ Uw
 tY
 Sy
 rN
-um
+wI
 WI
 yA
 JE


### PR DESCRIPTION
## About The Pull Request

Adds gas miners (oxygen, nitrogen, plasma) to both derelict drone stations (Kosmicheskaya Stantsiya 13 and Babylon Station 13)

Also adds a bluespace miner board to KS13

(And a large air tank to KS13 because I based the changes to KS13 on how KS13's atmospherics look on Monkestation, and KS13 has a large air tank on Monkestation, for whatever reason.)

There's some kind of bug that prevents plasma from rendering when the ruins are placed with "Map Template - Place", but it is there, and should show up when the ruin generates naturally. (Hopefully, at least.)

## Why it's Good for the Game

You can't fully pressurize either of the derelict drone stations without gas miners.

The plasma miners are there because I think being able to use more engine options like the TEG and turbine would be nice

Babylon has a bluespace miner board, why shouldn't KS13?

## Proof of Testing

<details>
<summary>Screenshots/Videos</summary>
<img width="563" height="846" alt="image" src="https://github.com/user-attachments/assets/476d80e1-47ac-4bb8-b060-f3f821cd18f1" />
<img width="664" height="885" alt="image" src="https://github.com/user-attachments/assets/94e94d53-7f52-4615-bf57-e8aab3da9cc8" />
<img width="401" height="351" alt="image" src="https://github.com/user-attachments/assets/fb97ae41-27c4-4170-884c-c78634c2811c" />
</details>

## Changelog

:cl:
map: Added gas miners (oxygen, nitrogen, plasma) to both derelict drone stations (Kosmicheskaya Stantsiya 13 and Babylon Station 13)
map: Added a bluespace miner board to KS13.
map: Added a large air tank to KS13.
/:cl: