### PR TITLE
Removes IAA from lawyers

### DIFF
--- a/modular_nova/modules/alternative_job_titles/code/alt_job_titles.dm
+++ b/modular_nova/modules/alternative_job_titles/code/alt_job_titles.dm
@@ -358,8 +358,8 @@
 		"Lawyer",
 		"Barrister",
 		"Defense Attorney",
-		"Sapient Resources Agent", // IRIS EDIT - it's "Sapient" now
-		"Internal Affairs Agent",
+		"Sophont Resources Agent", // OCULIS EDIT
+		// "Internal Affairs Agent", // OCULIS EDIT REMOVAL
 		"Legal Clerk",
 		"Prosecutor",
 		"Attorney At Law",


### PR DESCRIPTION

## About The Pull Request

Also renamed "Sapient" to "Sophont" since the line is right there from iris

## Why it's Good for the Game
Confusing.

## Proof of Testing
<details>
<summary>Screenshots/Videos</summary>

</details>

## Changelog
:cl:
del: Removed the Internal Affairs Agent Alt title from lawyers
/:cl:
