### PR TITLE
Makes the Stun option in the supplypod launcher much clearer

### DIFF
--- a/tgui/packages/tgui/interfaces/CentcomPodLauncher/constants.ts
+++ b/tgui/packages/tgui/interfaces/CentcomPodLauncher/constants.ts
@@ -192,6 +192,14 @@ export const EFFECTS_NORMAL: PodEffect[] = [
     soloSelected: 'effectTarget',
     title: 'Specific Target',
   },
+  // OCULIS EDIT ADDITION START - moved from harmful effects, renamed, icon changed
+  {
+    act: 'effectStun',
+    icon: 'lock',
+    soloSelected: 'effectStun',
+    title: 'Stunlock Target',
+  },
+  // OCULIS EDIT ADDITION END
   {
     act: 'effectBluespace',
     choiceNumber: 0,
@@ -290,12 +298,14 @@ export const EFFECTS_HARM: PodEffect[] = [
     soloSelected: 'effectShrapnel',
     title: 'Projectile Cloud',
   },
+  /* // OCULIS EDIT REMOVAL START - moved to normal effects
   {
     act: 'effectStun',
     icon: 'sun',
     soloSelected: 'effectStun',
     title: 'Stun',
   },
+  */ // OCULIS EDIT REMOVAL END
   {
     act: 'effectLimb',
     icon: 'socks',


### PR DESCRIPTION

## About The Pull Request
Moves the Stun effect from the Harmful category to the Normal category, renames it to "Stunlock Target", and changes its icon to a lock.
## Why it's Good for the Game
Makes it much clearer what the option does.
## Proof of Testing
<details>
<summary>Screenshots/Videos</summary>
<img width="912" height="550" alt="Screenshot 2026-06-21 004040" src="https://github.com/user-attachments/assets/d65eb5c5-d5dc-44fb-90ea-5d2056fabd17" />

https://github.com/user-attachments/assets/abd47896-7986-4b42-bcb1-7675cc7b778e



</details>

## Changelog
:cl:
admin: Makes the Stun option in the supplypod launcher menu clearer as to what it does (stunlocks the target).
/:cl:
