### PR TITLE
Allows cameras to take 1x1 photos

### DIFF
--- a/code/modules/modular_computers/file_system/programs/maintenance/camera.dm
+++ b/code/modules/modular_computers/file_system/programs/maintenance/camera.dm
@@ -92,7 +92,7 @@
 		"maxDescLength" = 128,
 		"maxCaptionLength" = 256,
 		"printCost" = 1,
-		"minSize" = 2,
+		"minSize" = 1,
 		"maxSize" = CAMERA_PICTURE_SIZE_HARD_LIMIT
 	)
 

--- a/code/modules/photography/camera/camera.dm
+++ b/code/modules/photography/camera/camera.dm
@@ -127,15 +127,15 @@
 		if(loc != user)
 			to_chat(user, span_warning("You must be holding the camera to continue!"))
 			return FALSE
-		desired_x = tgui_input_number(user, "Set camera half width Aperture", "Zoom", picture_size_x, CAMERA_PICTURE_SIZE_HARD_LIMIT, 2)
+		desired_x = tgui_input_number(user, "Set camera half width Aperture", "Zoom", picture_size_x, CAMERA_PICTURE_SIZE_HARD_LIMIT, 1)
 		if(!desired_x || QDELETED(user) || QDELETED(src) || !user.can_perform_action(src, FORBID_TELEKINESIS_REACH|ALLOW_PAI) || loc != user)
 			return FALSE
-		desired_y = tgui_input_number(user, "Set camera half height Aperture", "Zoom", picture_size_y, CAMERA_PICTURE_SIZE_HARD_LIMIT, 2)
+		desired_y = tgui_input_number(user, "Set camera half height Aperture", "Zoom", picture_size_y, CAMERA_PICTURE_SIZE_HARD_LIMIT, 1)
 		if(!desired_y || QDELETED(user) || QDELETED(src) || !user.can_perform_action(src, FORBID_TELEKINESIS_REACH|ALLOW_PAI) || loc != user)
 			return FALSE
 
-	picture_size_x = clamp(desired_x, 2, CAMERA_PICTURE_SIZE_HARD_LIMIT)
-	picture_size_y = clamp(desired_y, 2, CAMERA_PICTURE_SIZE_HARD_LIMIT)
+	picture_size_x = clamp(desired_x, 1, CAMERA_PICTURE_SIZE_HARD_LIMIT)
+	picture_size_y = clamp(desired_y, 1, CAMERA_PICTURE_SIZE_HARD_LIMIT)
 
 	if(user)
 		to_chat(user, span_notice("The dimensions of the picture will be [EXAMINE_HINT("[APERTURE_TO_METERS(picture_size_x)]x[APERTURE_TO_METERS(picture_size_y)]")]"))


### PR DESCRIPTION

## About The Pull Request

Security record consoles need a 1x1 photo in order to create a new security record. The minimum size for cameras is 3x3: this PR fixes that.
## Why it's Good for the Game

This makes it so you can create security records again, which is great for adding visitors to the station's records without a photo booth, or taking photos of inconsequential objects and making records for them.
## Proof of Testing
<details>
<summary>
Screenshots/Videos
</summary>
<img width="552" height="210" alt="imagen" src="https://github.com/user-attachments/assets/bd65ab9c-904f-4476-9530-713788bfa5ab" />
<img width="747" height="544" alt="imagen" src="https://github.com/user-attachments/assets/4bd82728-9337-4665-be32-a5931c6e3365" />
</details>

## Changelog
:cl:
fix: Cameras can now take 1x1 photos
/:cl:
