### PR TITLE
Add a Medical Records Console and a Jaws Of Recovery Cabinet to Void Raptor Station (among other minor changes)

### DIFF
--- a/_maps/map_files/VoidRaptor/VoidRaptor.dmm
+++ b/_maps/map_files/VoidRaptor/VoidRaptor.dmm
@@ -18104,8 +18104,8 @@
 /area/station/command/cc_dock)
 "fkX" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/effect/turf_decal/trimline/blue/filled/warning,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron/white/smooth_edge{
 	dir = 1
 	},
@@ -19085,6 +19085,8 @@
 /obj/effect/turf_decal/trimline/blue/filled/warning{
 	dir = 1
 	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/iron/white/smooth_edge,
 /area/station/medical/medbay/lobby)
 "fza" = (
@@ -32545,8 +32547,6 @@
 /turf/open/floor/catwalk_floor/iron_smooth,
 /area/station/science/ordnance/storage)
 "jpH" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/effect/turf_decal/trimline/blue/filled/warning{
 	dir = 6
 	},
@@ -46723,7 +46723,7 @@
 /obj/effect/turf_decal/trimline/blue/filled/line{
 	dir = 4
 	},
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
+/obj/machinery/computer/records/medical{
 	dir = 8
 	},
 /turf/open/floor/iron/white/smooth_edge{
@@ -50512,7 +50512,6 @@
 /obj/effect/turf_decal/trimline/blue/filled/line{
 	dir = 9
 	},
-/obj/machinery/status_display/evac/directional/west,
 /obj/machinery/firealarm/directional/north{
 	pixel_x = -7
 	},
@@ -50522,6 +50521,7 @@
 	normaldoorcontrol = 1;
 	pixel_x = 5
 	},
+/obj/structure/fireaxecabinet/jawsofrecovery/directional/west,
 /turf/open/floor/iron/white,
 /area/station/medical/medbay/lobby)
 "oiZ" = (
@@ -71819,13 +71819,13 @@
 /turf/open/floor/catwalk_floor/iron_smooth,
 /area/station/maintenance/starboard/aft)
 "tWj" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/door/firedoor,
 /obj/machinery/door/airlock/medical/glass{
 	name = "Medbay Desk"
 	},
 /obj/effect/mapping_helpers/airlock/access/all/medical/general,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/iron/white/smooth_large,
 /area/station/medical/medbay/lobby)
 "tWD" = (
@@ -77577,7 +77577,7 @@
 /area/station/maintenance/aft/lesser)
 "vAX" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2,
 /turf/open/floor/iron/white/smooth_large,
 /area/station/medical/medbay/lobby)
 "vBa" = (
@@ -117464,7 +117464,7 @@ jML
 aDx
 vAX
 fkX
-cOf
+tWj
 fyY
 oob
 qtB
@@ -117721,7 +117721,7 @@ bVR
 nCl
 nhi
 jpH
-tWj
+cOf
 kqY
 tQF
 haq

--- a/_maps/map_files/VoidRaptor/VoidRaptor.dmm
+++ b/_maps/map_files/VoidRaptor/VoidRaptor.dmm
@@ -29831,6 +29831,10 @@
 	pixel_x = -4;
 	pixel_y = 14
 	},
+/obj/item/surgicaldrill{
+	pixel_x = -2;
+	pixel_y = 16
+	},
 /turf/open/floor/iron/white/smooth_edge{
 	dir = 4
 	},


### PR DESCRIPTION
This is my first PR. Please let me know how I can improve and what I can fix!
## About The Pull Request
This PR adds a Medical Records Console and Jaws Of Recovery Cabinet to the Medbay Desk on Void Raptor Station. It also swaps the south Airlock and desk tiles, adjusting the atmospheric pipes to continue following mapping best practices.
<details>
<summary>Diagram of changes</summary>
<img width="1024" height="649" alt="mapedit-voidraptor-addmedrecconsole" src="https://github.com/user-attachments/assets/79a55fa7-273a-4635-b2c0-d4c0694ae29f" />
</details>

## Why it's Good for the Game
- Adding a Medical Records Console to Medbay Desk makes it more accessible, as currently the only way for most Medical Personnel to change medical records is via a laptop in the very back of Medbay.
- Adding a Jaws Of Recovery Cabinet allows Paramedics to obtain a crucial component of their intended arsenal.
- Swapping the Airlock and desk makes the room feel less cramped and easier to enter/exit.
- Adjusting the piping for best practices makes it more accessible to Engineers.
## Proof of Testing
There wasn't a lot to test, but I did launch the game and interact with everything successfully. Image below.
<details>
<summary>Screenshots/Videos</summary>
<img width="356" height="493" alt="image" src="https://github.com/user-attachments/assets/990eace8-6130-4a5f-9777-53561f3636a6" />
</details>

## Changelog
:cl:
map: Modified Void Raptor class station layout:
map: Modified the Medbay Desk:
add: Installed a Jaws Of Recovery Cabinet- for Paramedics to use
add: Installed a Medical Records Console- for Medical personnel's ease of access
del: Dissembled a Status Display- to make room for the Jaws Of Recovery Cabinet
qol: Swapped the south Airlock and desk- to help the area feel less cramped
fix: Adjusted atmospheric piping- to follow best practices after the aforementioned changes
/:cl:
