### PR TITLE
fix lavaland being near-impossible to see

### DIFF
--- a/modular_nova/master_files/code/game/turfs/closed/minerals.dm
+++ b/modular_nova/master_files/code/game/turfs/closed/minerals.dm
@@ -1,4 +1,6 @@
+/* // OCULIS EDIT REMOVAL START - stop making lavaland impossible to see
 // Seting color var is kinda depricated now
 /turf/closed/mineral/Initialize(mapload)
 	add_atom_colour("#677", FIXED_COLOUR_PRIORITY)
 	return ..()
+*/ // OCULIS EDIT REMOVAL END


### PR DESCRIPTION

## About The Pull Request

this nukes a stupid nova override that colors _all minerals_ with `#667777` for some goddamn reason

## Why it's Good for the Game

i like being able to see

## Proof of Testing

before fix:
<img width="407" height="578" alt="2026-06-30 (1782830529) ~ dreamseeker" src="https://github.com/user-attachments/assets/6f148899-5769-45e7-8e48-2606219269fd" />

after fix:
<img width="450" height="688" alt="2026-06-30 (1782830503) ~ dreamseeker" src="https://github.com/user-attachments/assets/bebc80cf-12a7-4516-84f5-df97abea17c6" />

## Changelog
:cl:
fix: You should actually be able to properly tell the difference between flooring and rocks in lavaland now.
/:cl:
