### PR TITLE
Makes long-range gas analyzers a small item like normal range ones because I fumbled with my pockets 1 time

### DIFF
--- a/modular_oculis/master_files/code/game/objects/tools.dm
+++ b/modular_oculis/master_files/code/game/objects/tools.dm
@@ -1,0 +1,2 @@
+/obj/item/analyzer/ranged
+	w_class = WEIGHT_CLASS_SMALL

--- a/tgstation.dme
+++ b/tgstation.dme
@@ -10083,6 +10083,7 @@
 #include "modular_oculis\master_files\code\datums\http.dm"
 #include "modular_oculis\master_files\code\game\atoms_movable.dm"
 #include "modular_oculis\master_files\code\game\area\areas\mining.dm"
+#include "modular_oculis\master_files\code\game\objects\tools.dm"
 #include "modular_oculis\master_files\code\game\turfs\turf.dm"
 #include "modular_oculis\master_files\code\game\turfs\open\openspace.dm"
 #include "modular_oculis\master_files\code\modules\admin\verbs\getlogs.dm"


### PR DESCRIPTION

## About The Pull Request
Title 
## Why it's Good for the Game
I don't really see much reason why they shouldn't both be pocketable
## Proof of Testing
<details>
<summary>Screenshots/Videos</summary>
<img width="630" height="265" alt="image" src="https://github.com/user-attachments/assets/27fe8aac-ecaf-4070-80a9-0d9d29a240d6" />

</details>

## Changelog
:cl:
qol: long range gas analyzers fit in pockets like short range ones
/:cl:
