### PR TITLE
Makes the (useless?) magnifying glass small-sized instead of normal-sized

### DIFF
--- a/modular_nova/modules/xenoarch/code/modules/research/xenoarch/glassblowing_integration.dm
+++ b/modular_nova/modules/xenoarch/code/modules/research/xenoarch/glassblowing_integration.dm
@@ -3,7 +3,7 @@
 	desc = "A tool that, with the assistance of a magnifying lens, allows you to view what is small."
 	icon_state = "magnifying_glass"
 	custom_materials = list(/datum/material/wood = SHEET_MATERIAL_AMOUNT)
-	w_class = WEIGHT_CLASS_SMALL
+	w_class = WEIGHT_CLASS_SMALL // OCULIS EDIT ADDITION
 
 /datum/crafting_recipe/magnifying_glass
 	name = "Magnifying Glass"

--- a/modular_nova/modules/xenoarch/code/modules/research/xenoarch/glassblowing_integration.dm
+++ b/modular_nova/modules/xenoarch/code/modules/research/xenoarch/glassblowing_integration.dm
@@ -3,6 +3,7 @@
 	desc = "A tool that, with the assistance of a magnifying lens, allows you to view what is small."
 	icon_state = "magnifying_glass"
 	custom_materials = list(/datum/material/wood = SHEET_MATERIAL_AMOUNT)
+	w_class = WEIGHT_CLASS_SMALL
 
 /datum/crafting_recipe/magnifying_glass
 	name = "Magnifying Glass"


### PR DESCRIPTION

## About The Pull Request
Makes the (useless?) magnifying glass a small-sized item instead of normal-sized.
## Why it's Good for the Game
A magnifying glass makes more sense to be small, and doesn't seem to have any balancing reason to warrant it being larger than a small item.
## Proof of Testing
None, trivial change, can test if requested.
<details>
<summary>Screenshots/Videos</summary>

</details>

## Changelog
:cl:
qol: Made the magnifying glass a small item instead of a normal item.
/:cl:
