### PR TITLE
Makes the Compact Shotgun Actually Compact (or: Size Matters)

### DIFF
--- a/code/modules/projectiles/guns/ballistic/shotgun.dm
+++ b/code/modules/projectiles/guns/ballistic/shotgun.dm
@@ -105,7 +105,7 @@
 	desc = "A compact version of the semi automatic combat shotgun. Lower magazine capacity, but more easily carried."
 	icon_state = "cshotgunc"
 	accepted_magazine_type = /obj/item/ammo_box/magazine/internal/shot/com/compact
-	w_class = WEIGHT_CLASS_BULKY
+	w_class = WEIGHT_CLASS_NORMAL // OCULIS EDIT, ORIGINAL:	w_class = WEIGHT_CLASS_BULKY
 	weapon_weight = WEAPON_MEDIUM
 
 //component for seclight attachment


### PR DESCRIPTION

## About The Pull Request
Changes the W_CLASS of the shotgun from bulky to normal. This allows it to be stored in the suit slot as normal, sec belt / webbing like a disabler, and backpack, much like the cut-down M64.

## Why it's Good for the Game
The compact shotgun is currently considered bulky. This prevents it from being stowed in any belt, webbing or backpack despite it being a cut-down version of the cull combat shotgun. As it stands, there is no reason (short of money and one shell) to not buy a Bobr, or worse as I've seen, outright just take a M-64 from the armory in lieu of the compact shotgun, as it only fits on the suit slot.
## Proof of Testing
<details>
<summary>Screenshots/Videos</summary>
[
<img width="933" height="612" alt="compacthshotgun" src="https://github.com/user-attachments/assets/5edd4507-d298-42e6-9160-8e49ceae39be" />
](url)
</details>

## Changelog
:cl:
balance: Changed the size of the compact combat shotgun down to normal from bulky, allowing it to be used in the security belts, webbing and backpack.
/:cl:
