### PR TITLE
Allows venomous bite users to bite themselves

### DIFF
--- a/modular_nova/master_files/code/datums/quirks/positive_quirks/venomous/venomous_bite.dm
+++ b/modular_nova/master_files/code/datums/quirks/positive_quirks/venomous/venomous_bite.dm
@@ -76,7 +76,7 @@
 		if(!(owner.zone_selected in GLOB.arm_zones))
 			owner.balloon_alert(owner, "can only bite your arms!")
 			return FALSE
-		owner.visible_message(span_warning("[owner] starts to bite %PRONOUN_themself!"), span_userdanger("You start to bite yourself!"))
+		owner.visible_message(span_warning("[owner] starts to bite [owner.p_them()]self!"), span_userdanger("You start to bite yourself!"))
 	// OCULIS EDIT ADDITION END
 	owner.balloon_alert_to_viewers("biting...")
 	var/result = do_after(owner, 0.5 SECONDS, target_atom, IGNORE_HELD_ITEM)

--- a/modular_nova/master_files/code/datums/quirks/positive_quirks/venomous/venomous_bite.dm
+++ b/modular_nova/master_files/code/datums/quirks/positive_quirks/venomous/venomous_bite.dm
@@ -74,7 +74,8 @@
 		to_chat(target_atom, span_userdanger("[owner] starts to bite you!"))
 	else
 		if(!(owner.zone_selected in GLOB.arm_zones))
-			owner.balloon_alert(owner, "can only bite your own arms!")
+			owner.balloon_alert(owner, "can only bite your arms!")
+			return FALSE
 		owner.visible_message(span_warning("[owner] starts to bite %PRONOUN_themself!"), span_userdanger("You start to bite yourself!"))
 	// OCULIS EDIT ADDITION END
 	owner.balloon_alert_to_viewers("biting...")

--- a/modular_nova/master_files/code/datums/quirks/positive_quirks/venomous/venomous_bite.dm
+++ b/modular_nova/master_files/code/datums/quirks/positive_quirks/venomous/venomous_bite.dm
@@ -60,12 +60,23 @@
 		owner.balloon_alert(owner, "too far!")
 		return FALSE
 
+	/* // OCULIS EDIT REMOVAL START
 	if (target_atom == owner)
 		owner.balloon_alert(owner, "can't bite yourself!")
 		return FALSE
 
 	owner.visible_message(span_warning("[owner] starts to bite [target_atom]!"), span_warning("You start to bite [target_atom]!"), ignored_mobs = target_atom)
 	to_chat(target_atom, span_userdanger("[owner] starts to bite you!"))
+	*/ // OCULIS EDIT REMOVAL END
+	// OCULIS EDIT ADDITION START
+	if (target_atom != owner)
+		owner.visible_message(span_warning("[owner] starts to bite [target_atom]!"), span_warning("You start to bite [target_atom]!"), ignored_mobs = target_atom)
+		to_chat(target_atom, span_userdanger("[owner] starts to bite you!"))
+	else
+		if(!(owner.zone_selected in GLOB.arm_zones))
+			owner.balloon_alert(owner, "can only bite your own arms!")
+		owner.visible_message(span_warning("[owner] starts to bite %PRONOUN_themself!"), span_userdanger("You start to bite yourself!"))
+	// OCULIS EDIT ADDITION END
 	owner.balloon_alert_to_viewers("biting...")
 	var/result = do_after(owner, 0.5 SECONDS, target_atom, IGNORE_HELD_ITEM)
 	if (!result)

--- a/modular_nova/master_files/code/datums/quirks/positive_quirks/venomous/venomous_bite.dm
+++ b/modular_nova/master_files/code/datums/quirks/positive_quirks/venomous/venomous_bite.dm
@@ -97,8 +97,8 @@
 	var/obj/item/bodypart/part = target.get_bodypart(target_zone)
 
 	var/text = "[owner] sinks [owner.p_their()] teeth into [target]'s [target.parse_zone_with_bodypart(target_zone)]!"
-	var/self_message = "You sink your teeth into [target]'s [target.parse_zone_with_bodypart(target_zone)]!"
-	var/victim_message = "[owner] sinks [owner.p_their()] teeth into your [target.parse_zone_with_bodypart(target_zone)]!"
+	var/self_message = target_atom != owner ? "You sink your teeth into [target]'s [target.parse_zone_with_bodypart(target_zone)]!":null // OCULIS EDIT, ORIGINAL: var/self_message = "You sink your teeth into [target]'s [target.parse_zone_with_bodypart(target_zone)]!"
+	var/victim_message = target_atom != owner ? "[owner] sinks [owner.p_their()] teeth into your [target.parse_zone_with_bodypart(target_zone)]!":"You sink your teeth into your [target.parse_zone_with_bodypart(target_zone)]!" // OCULIS EDIT, ORIGINAL: var/victim_message = "[owner] sinks [owner.p_their()] teeth into your [target.parse_zone_with_bodypart(target_zone)]!"
 
 	var/covered = FALSE
 	if (ishuman(target))
@@ -108,8 +108,8 @@
 				covered = TRUE
 
 				text = "[owner] tries to bite [target], but breaks [owner.p_their()] teeth on [target]'s clothing! Ouch!"
-				self_message = "You try to bite [target], but you break your teeth on [target.p_their()] clothing! Ouch!"
-				victim_message = "[owner] tries to bite you, but breaks [owner.p_their()] teeth on your clothing! Ouch!"
+				self_message = target_atom != owner ? "You try to bite [target], but you break your teeth on [target.p_their()] clothing! Ouch!":null // OCULIS EDIT, ORIGINAL: self_message = "You try to bite [target], but you break your teeth on [target.p_their()] clothing! Ouch!"
+				victim_message = target_atom != owner ? "[owner] tries to bite you, but breaks [owner.p_their()] teeth on your clothing! Ouch!":"You try to bite yourself, but break your teeth on your clothing! Ouch!" // OCULIS EDIT, ORIGINAL: victim_message = "[owner] tries to bite you, but breaks [owner.p_their()] teeth on your clothing! Ouch!"
 
 				owner.emote("scream")
 				if (isliving(owner))

--- a/modular_nova/master_files/code/datums/quirks/positive_quirks/venomous/venomous_bite.dm
+++ b/modular_nova/master_files/code/datums/quirks/positive_quirks/venomous/venomous_bite.dm
@@ -98,8 +98,8 @@
 
 	var/text = "[owner] sinks [owner.p_their()] teeth into [target]'s [target.parse_zone_with_bodypart(target_zone)]!"
 	/* // OCULIS EDIT REMOVAL START
-	var/self_message = target != owner ? "You sink your teeth into [target]'s [target.parse_zone_with_bodypart(target_zone)]!":null // OCULIS EDIT, ORIGINAL: var/self_message = "You sink your teeth into [target]'s [target.parse_zone_with_bodypart(target_zone)]!"
-	var/victim_message = target != owner ? "[owner] sinks [owner.p_their()] teeth into your [target.parse_zone_with_bodypart(target_zone)]!":"You sink your teeth into your [target.parse_zone_with_bodypart(target_zone)]!" // OCULIS EDIT, ORIGINAL: var/victim_message = "[owner] sinks [owner.p_their()] teeth into your [target.parse_zone_with_bodypart(target_zone)]!"
+	var/self_message = "You sink your teeth into [target]'s [target.parse_zone_with_bodypart(target_zone)]!"
+	var/victim_message = "[owner] sinks [owner.p_their()] teeth into your [target.parse_zone_with_bodypart(target_zone)]!"
 	*/ // OCULIS EDIT REMOVAL END
 	// OCULIS EDIT ADDITION START
 	var/self_message
@@ -121,8 +121,8 @@
 
 				text = "[owner] tries to bite [target], but breaks [owner.p_their()] teeth on [target]'s clothing! Ouch!"
 				/* // OCULIS EDIT REMOVAL START
-				self_message = target != owner ? "You try to bite [target], but you break your teeth on [target.p_their()] clothing! Ouch!":null // OCULIS EDIT, ORIGINAL: self_message = "You try to bite [target], but you break your teeth on [target.p_their()] clothing! Ouch!"
-				victim_message = target != owner ? "[owner] tries to bite you, but breaks [owner.p_their()] teeth on your clothing! Ouch!":"You try to bite yourself, but break your teeth on your clothing! Ouch!" // OCULIS EDIT, ORIGINAL: victim_message = "[owner] tries to bite you, but breaks [owner.p_their()] teeth on your clothing! Ouch!"
+				self_message = "You try to bite [target], but you break your teeth on [target.p_their()] clothing! Ouch!"
+				victim_message = "[owner] tries to bite you, but breaks [owner.p_their()] teeth on your clothing! Ouch!"
 				*/ // OCULIS EDIT REMOVAL END
 				// OCULIS EDIT ADDITION START
 				if(target != owner)

--- a/modular_nova/master_files/code/datums/quirks/positive_quirks/venomous/venomous_bite.dm
+++ b/modular_nova/master_files/code/datums/quirks/positive_quirks/venomous/venomous_bite.dm
@@ -97,8 +97,20 @@
 	var/obj/item/bodypart/part = target.get_bodypart(target_zone)
 
 	var/text = "[owner] sinks [owner.p_their()] teeth into [target]'s [target.parse_zone_with_bodypart(target_zone)]!"
-	var/self_message = target_atom != owner ? "You sink your teeth into [target]'s [target.parse_zone_with_bodypart(target_zone)]!":null // OCULIS EDIT, ORIGINAL: var/self_message = "You sink your teeth into [target]'s [target.parse_zone_with_bodypart(target_zone)]!"
-	var/victim_message = target_atom != owner ? "[owner] sinks [owner.p_their()] teeth into your [target.parse_zone_with_bodypart(target_zone)]!":"You sink your teeth into your [target.parse_zone_with_bodypart(target_zone)]!" // OCULIS EDIT, ORIGINAL: var/victim_message = "[owner] sinks [owner.p_their()] teeth into your [target.parse_zone_with_bodypart(target_zone)]!"
+	/* // OCULIS EDIT REMOVAL START
+	var/self_message = target != owner ? "You sink your teeth into [target]'s [target.parse_zone_with_bodypart(target_zone)]!":null // OCULIS EDIT, ORIGINAL: var/self_message = "You sink your teeth into [target]'s [target.parse_zone_with_bodypart(target_zone)]!"
+	var/victim_message = target != owner ? "[owner] sinks [owner.p_their()] teeth into your [target.parse_zone_with_bodypart(target_zone)]!":"You sink your teeth into your [target.parse_zone_with_bodypart(target_zone)]!" // OCULIS EDIT, ORIGINAL: var/victim_message = "[owner] sinks [owner.p_their()] teeth into your [target.parse_zone_with_bodypart(target_zone)]!"
+	*/ // OCULIS EDIT REMOVAL END
+	// OCULIS EDIT ADDITION START
+	var/self_message
+	var/victim_message
+	if(target != owner)
+		self_message = "You sink your teeth into [target]'s [target.parse_zone_with_bodypart(target_zone)]!"
+		victim_message = "[owner] sinks [owner.p_their()] teeth into your [target.parse_zone_with_bodypart(target_zone)]!"
+	else
+		self_message = null
+		victim_message = "You sink your teeth into your [target.parse_zone_with_bodypart(target_zone)]!"
+	// OCULIS EDIT ADDITION END
 
 	var/covered = FALSE
 	if (ishuman(target))
@@ -108,8 +120,18 @@
 				covered = TRUE
 
 				text = "[owner] tries to bite [target], but breaks [owner.p_their()] teeth on [target]'s clothing! Ouch!"
-				self_message = target_atom != owner ? "You try to bite [target], but you break your teeth on [target.p_their()] clothing! Ouch!":null // OCULIS EDIT, ORIGINAL: self_message = "You try to bite [target], but you break your teeth on [target.p_their()] clothing! Ouch!"
-				victim_message = target_atom != owner ? "[owner] tries to bite you, but breaks [owner.p_their()] teeth on your clothing! Ouch!":"You try to bite yourself, but break your teeth on your clothing! Ouch!" // OCULIS EDIT, ORIGINAL: victim_message = "[owner] tries to bite you, but breaks [owner.p_their()] teeth on your clothing! Ouch!"
+				/* // OCULIS EDIT REMOVAL START
+				self_message = target != owner ? "You try to bite [target], but you break your teeth on [target.p_their()] clothing! Ouch!":null // OCULIS EDIT, ORIGINAL: self_message = "You try to bite [target], but you break your teeth on [target.p_their()] clothing! Ouch!"
+				victim_message = target != owner ? "[owner] tries to bite you, but breaks [owner.p_their()] teeth on your clothing! Ouch!":"You try to bite yourself, but break your teeth on your clothing! Ouch!" // OCULIS EDIT, ORIGINAL: victim_message = "[owner] tries to bite you, but breaks [owner.p_their()] teeth on your clothing! Ouch!"
+				*/ // OCULIS EDIT REMOVAL END
+				// OCULIS EDIT ADDITION START
+				if(target != owner)
+					self_message = "You try to bite [target], but you break your teeth on [target.p_their()] clothing! Ouch!"
+					victim_message = "[owner] tries to bite you, but breaks [owner.p_their()] teeth on your clothing! Ouch!"
+				else
+					self_message = null
+					victim_message = "You try to bite yourself, but break your teeth on your clothing! Ouch!"
+				// OCULIS EDIT ADDITION END
 
 				owner.emote("scream")
 				if (isliving(owner))


### PR DESCRIPTION

## About The Pull Request
Allows venomous bite users to bite themselves. Adds checks to require biting your own arms only and suitable messages for biting yourself.
## Why it's Good for the Game
There isn't really a reason you shouldn't be able to bite yourself with it. Venomous bite is already balanced by cooldowns, and this allows for more character gimmicks using the bite. It's not very easy to accidentally bite yourself because of the do_after, chat alert, and arm targeting requirement.
## Proof of Testing
<details>
<summary>Screenshots/Videos</summary>
<img width="392" height="218" alt="Screenshot 2026-07-03 012239 2" src="https://github.com/user-attachments/assets/84351f8f-6925-4be9-a6a0-73f4bde7a472" />
<img width="607" height="147" alt="image" src="https://github.com/user-attachments/assets/abd02caf-0b83-4bd3-aee8-7a0980aba19a" />
<img width="470" height="79" alt="Screenshot 2026-07-03 012307" src="https://github.com/user-attachments/assets/9f508ccb-4a17-435f-af02-85e41984df8a" />
<img width="597" height="167" alt="image" src="https://github.com/user-attachments/assets/d63cb872-79bd-4be8-93c3-07b68e5b4036" />
</details>

## Changelog
:cl:
add: You can now bite yourself with your venomous bite.
/:cl:
