### PR TITLE
Departmental Guards: Re-Sketchified (Unrestricting "Paroled Convict")

### DIFF
--- a/code/__DEFINES/~nova_defines/jobs.dm
+++ b/code/__DEFINES/~nova_defines/jobs.dm
@@ -8,7 +8,7 @@
 #define SEC_RESTRICTED_QUIRKS "Blind" = TRUE, "Brain Tumor" = TRUE, "Deaf" = TRUE, "Paraplegic" = TRUE, "Hemiplegic" = TRUE, "Foreigner" = TRUE, "Pacifist" = TRUE, "No Guns" = TRUE, "Illiterate" = TRUE, "Nerve Stapled" = TRUE, "Underworld Connections" = TRUE, "Stowaway" = TRUE, "Paroled Convict" = TRUE  //IRIS EDIT - Adds Stowaway, removes Mute
 #define HEAD_RESTRICTED_QUIRKS "Blind" = TRUE, "Deaf" = TRUE, "Mute" = TRUE, "Foreigner" = TRUE, "Brain Tumor" = TRUE, "Illiterate" = TRUE, "Underworld Connections" = TRUE, "Stowaway" = TRUE, "Stowaway" = TRUE, "Paroled Convict" = TRUE   //IRIS EDIT - Adds Stowaway and Convict
 #define HEAD_RESTRICTED_QUIRKS_QM "Blind" = TRUE, "Deaf" = TRUE, "Mute" = TRUE, "Foreigner" = TRUE, "Brain Tumor" = TRUE, "Illiterate" = TRUE, "Stowaway" = TRUE, "Paroled Convict" = TRUE   //IRIS EDIT - Adds Stowaway and Convict
-#define GUARD_RESTRICTED_QUIRKS "Blind" = TRUE, "Deaf" = TRUE, "Foreigner" = TRUE, "Pacifist" = TRUE, "Nerve Stapled" = TRUE, "Stowaway" = TRUE, "Underworld Connections" = TRUE,  //IRIS EDIT - Adds Stowaway, Convict and Underworld Connections // OCULIS EDIT - Removes Convict
+#define GUARD_RESTRICTED_QUIRKS "Blind" = TRUE, "Deaf" = TRUE, "Foreigner" = TRUE, "Pacifist" = TRUE, "Nerve Stapled" = TRUE, "Stowaway" = TRUE, "Underworld Connections" = TRUE // OCULIS EDIT - Adds Stowaway and Underworld Connections 
 #define PRISONER_RESTRICTED_QUIRKS "Underworld Connections" = TRUE, "Stowaway" = TRUE //IRIS EDIT - Adds Stowaway
 
 #define SEC_RESTRICTED_SPECIES SPECIES_ABDUCTORWEAK = TRUE, SPECIES_GOLEMWEAK = TRUE, SPECIES_DULLAHAN = TRUE

--- a/code/__DEFINES/~nova_defines/jobs.dm
+++ b/code/__DEFINES/~nova_defines/jobs.dm
@@ -8,7 +8,7 @@
 #define SEC_RESTRICTED_QUIRKS "Blind" = TRUE, "Brain Tumor" = TRUE, "Deaf" = TRUE, "Paraplegic" = TRUE, "Hemiplegic" = TRUE, "Foreigner" = TRUE, "Pacifist" = TRUE, "No Guns" = TRUE, "Illiterate" = TRUE, "Nerve Stapled" = TRUE, "Underworld Connections" = TRUE, "Stowaway" = TRUE, "Paroled Convict" = TRUE  //IRIS EDIT - Adds Stowaway, removes Mute
 #define HEAD_RESTRICTED_QUIRKS "Blind" = TRUE, "Deaf" = TRUE, "Mute" = TRUE, "Foreigner" = TRUE, "Brain Tumor" = TRUE, "Illiterate" = TRUE, "Underworld Connections" = TRUE, "Stowaway" = TRUE, "Stowaway" = TRUE, "Paroled Convict" = TRUE   //IRIS EDIT - Adds Stowaway and Convict
 #define HEAD_RESTRICTED_QUIRKS_QM "Blind" = TRUE, "Deaf" = TRUE, "Mute" = TRUE, "Foreigner" = TRUE, "Brain Tumor" = TRUE, "Illiterate" = TRUE, "Stowaway" = TRUE, "Paroled Convict" = TRUE   //IRIS EDIT - Adds Stowaway and Convict
-#define GUARD_RESTRICTED_QUIRKS "Blind" = TRUE, "Deaf" = TRUE, "Foreigner" = TRUE, "Pacifist" = TRUE, "Nerve Stapled" = TRUE, "Stowaway" = TRUE, "Underworld Connections" = TRUE, "Paroled Convict" = TRUE  //IRIS EDIT - Adds Stowaway, Convict and Underworld Connections
+#define GUARD_RESTRICTED_QUIRKS "Blind" = TRUE, "Deaf" = TRUE, "Foreigner" = TRUE, "Pacifist" = TRUE, "Nerve Stapled" = TRUE, "Stowaway" = TRUE, "Underworld Connections" = TRUE,  //IRIS EDIT - Adds Stowaway, Convict and Underworld Connections // OCULIS EDIT - Removes Convict
 #define PRISONER_RESTRICTED_QUIRKS "Underworld Connections" = TRUE, "Stowaway" = TRUE //IRIS EDIT - Adds Stowaway
 
 #define SEC_RESTRICTED_SPECIES SPECIES_ABDUCTORWEAK = TRUE, SPECIES_GOLEMWEAK = TRUE, SPECIES_DULLAHAN = TRUE


### PR DESCRIPTION

## About The Pull Request
Removes "Paroled Convict" from the restricted quirks of departmental guards.
## Why it's Good for the Game
Departmental guards have always been a "half-officer" of security - They're meant to be sketchy, but they're not actually **allowed** to take some of the sketchier quirks. This fixes that. Underworld Connections is still a customs-agent exclusive because it's fitting for the cargo guard to be able to run their own black market operation between the other guards.
## Proof of Testing
<details>
<summary>Screenshots/Videos</summary>
<img width="749" height="594" alt="image" src="https://github.com/user-attachments/assets/ecec534b-90f6-4b66-9178-0fa9d470540a" />
<img width="997" height="829" alt="image" src="https://github.com/user-attachments/assets/436e0f8d-fdc2-46ac-a019-e499c8006429" />
</details>

## Changelog
:cl:
del: Removed the restriction barring characters with the "Paroled Convict" quirk from playing departmental guards.
/:cl:
