### PR TITLE
Adds some alt-titles for certain roles

### DIFF
--- a/modular_nova/modules/alternative_job_titles/code/alt_job_titles.dm
+++ b/modular_nova/modules/alternative_job_titles/code/alt_job_titles.dm
@@ -333,7 +333,7 @@
 		"Human Resources Officer",
 		"Executive Officer",
 		"First Officer", // OCULIS EDIT ADDITION
-		"Senior Sophont Resources Agent", // OCULIS EDIT
+		"Senior Sophont Resources Agent", // OCULIS EDIT ADDITION
 	)
 
 /datum/job/head_of_security

--- a/modular_nova/modules/alternative_job_titles/code/alt_job_titles.dm
+++ b/modular_nova/modules/alternative_job_titles/code/alt_job_titles.dm
@@ -332,8 +332,9 @@
 		"Employment Officer",
 		"Human Resources Officer",
 		"Executive Officer",
-		"First Officer", // OCULIS EDIT - NEW TITLE
-		"Senior Sapient Resources Agent", // IRIS EDIT - new title
+		"First Officer", // OCULIS EDIT ADDITION
+		// "Senior Sapient Resources Agent", // IRIS EDIT - new title
+		"Senior Sophont Resources Agent", // OCULIS EDIT
 	)
 
 /datum/job/head_of_security
@@ -341,7 +342,7 @@
 		"Head of Security",
 		"Chief Constable",
 		"Chief of Security",
-		"Chief Security Officer", // OCULIS EDIT - NEW TITLE
+		"Chief Security Officer", // OCULIS EDIT ADDITION
 		"Security Commander",
 		"Security Supervisor",
 		"Security Director",
@@ -414,9 +415,9 @@
 /datum/job/prisoner
 	alt_titles = list(
 		"Prisoner",
-		"Convict", // OCULIS EDIT - NEW TITLE
+		"Convict", // OCULIS EDIT ADDITION
 		"Minimum Security Prisoner",
-		"Medium Security Prisoner", // OCULIS EDIT - NEW TITLE
+		"Medium Security Prisoner", // OCULIS EDIT ADDITION
 		"Maximum Security Prisoner",
 		"SuperMax Security Prisoner",
 		"Protective Custody Prisoner",
@@ -497,8 +498,8 @@
 		"Security Operative",
 		"Security Cadet",
 		"Security Specialist",
-		"Junior Officer", // OCULIS EDIT
-		"Senior Officer", // OCULIS EDIT
+		"Junior Officer", // OCULIS EDIT ADDITION
+		"Senior Officer", // OCULIS EDIT ADDITION
 		"Deputy",
 		"Constable",
 	)
@@ -554,8 +555,8 @@
 		"Brig Sergeant",
 		"Brig Governor",
 		"Dispatch Officer",
-		"Armaments Supervisor", // OCULIS EDIT
+		"Armaments Supervisor", // OCULIS EDIT ADDITION
 		"Jailer",
-		"Sentry", // OCULIS EDIT
-		"Armorer", // OCULIS EDIT
+		"Sentry", // OCULIS EDIT ADDITION
+		"Armorer", // OCULIS EDIT ADDITION
 	)

--- a/modular_nova/modules/alternative_job_titles/code/alt_job_titles.dm
+++ b/modular_nova/modules/alternative_job_titles/code/alt_job_titles.dm
@@ -332,6 +332,7 @@
 		"Employment Officer",
 		"Human Resources Officer",
 		"Executive Officer",
+		"First Officer", // OCULIS EDIT - NEW TITLE
 		"Senior Sapient Resources Agent", // IRIS EDIT - new title
 	)
 
@@ -340,6 +341,7 @@
 		"Head of Security",
 		"Chief Constable",
 		"Chief of Security",
+		"Chief Security Officer", // OCULIS EDIT - NEW TITLE
 		"Security Commander",
 		"Security Supervisor",
 		"Security Director",
@@ -412,7 +414,9 @@
 /datum/job/prisoner
 	alt_titles = list(
 		"Prisoner",
+		"Convict", // OCULIS EDIT - NEW TITLE
 		"Minimum Security Prisoner",
+		"Medium Security Prisoner", // OCULIS EDIT - NEW TITLE
 		"Maximum Security Prisoner",
 		"SuperMax Security Prisoner",
 		"Protective Custody Prisoner",
@@ -493,6 +497,8 @@
 		"Security Operative",
 		"Security Cadet",
 		"Security Specialist",
+		"Junior Officer", // OCULIS EDIT
+		"Senior Officer", // OCULIS EDIT
 		"Deputy",
 		"Constable",
 	)
@@ -548,5 +554,8 @@
 		"Brig Sergeant",
 		"Brig Governor",
 		"Dispatch Officer",
+		"Armaments Supervisor", // OCULIS EDIT
 		"Jailer",
+		"Sentry", // OCULIS EDIT
+		"Armorer", // OCULIS EDIT
 	)

--- a/modular_nova/modules/alternative_job_titles/code/alt_job_titles.dm
+++ b/modular_nova/modules/alternative_job_titles/code/alt_job_titles.dm
@@ -333,7 +333,6 @@
 		"Human Resources Officer",
 		"Executive Officer",
 		"First Officer", // OCULIS EDIT ADDITION
-		// "Senior Sapient Resources Agent", // IRIS EDIT - new title
 		"Senior Sophont Resources Agent", // OCULIS EDIT
 	)
 


### PR DESCRIPTION

## About The Pull Request

**Adds the following titles:**
Chief Security Officer (HoS)
First Officer (HoP)
Armorer (Warden)
Armaments Supervisor (Warden)
Sentry (Warden)
Senior Officer (Security Officer)
Junior Officer (Security Officer)
Convict (Prisoner)
Medium Security Prisoner (Prisoner)

## Why it's Good for the Game
Variety is the spice of life, and these are primarily requests taken from round-end in a conversation.

## Proof of Testing
<details>
<summary>Screenshots/Videos</summary>
<img width="155" height="198" alt="image" src="https://github.com/user-attachments/assets/d5152b3e-3e61-48dc-9a28-8c774b0a4875" />
<img width="148" height="186" alt="image" src="https://github.com/user-attachments/assets/88df258e-e54a-491f-ad5a-12aa768c7b99" />
<img width="138" height="158" alt="image" src="https://github.com/user-attachments/assets/6f5f59f6-298f-4bf0-86b1-a6070c8a36bf" />
<img width="140" height="194" alt="image" src="https://github.com/user-attachments/assets/14a8ebaf-c4ed-4621-9fa1-45900274210e" />
<img width="152" height="170" alt="image" src="https://github.com/user-attachments/assets/ba534aa0-78a1-458f-bc83-2f9f5b6843f2" />
</details>

## Changelog
:cl:
add: Adds titles to HoS, HoP, Warden, Security Officer, and Prisoner.
/:cl:
