### PR TITLE
Replaces the ghost cafe mirrors with proper directional ones

### DIFF
--- a/_maps/map_files/generic/CentCom_oculis.dmm
+++ b/_maps/map_files/generic/CentCom_oculis.dmm
@@ -3791,9 +3791,7 @@
 /area/centcom/holding/cafe)
 "aRx" = (
 /obj/structure/sink/directional/east,
-/obj/structure/mirror{
-	pixel_y = 32
-	},
+/obj/structure/mirror/directional/north,
 /obj/structure/toilet{
 	pixel_y = 14
 	},
@@ -6670,9 +6668,7 @@
 /turf/open/floor/iron,
 /area/centcom/interlink)
 "dbn" = (
-/obj/structure/mirror{
-	pixel_y = 32
-	},
+/obj/structure/mirror/directional/north,
 /obj/structure/toilet{
 	pixel_y = 14
 	},
@@ -16555,15 +16551,13 @@
 	pixel_x = -25;
 	specialfunctions = 4
 	},
-/obj/structure/mirror{
-	pixel_y = -31
-	},
 /obj/machinery/light/floor{
 	alpha = 0;
 	invisibility = 100;
 	light_range = 10;
 	nightshift_light_power = 10
 	},
+/obj/structure/mirror/directional/south,
 /turf/open/floor/wood,
 /area/centcom/holding/cafe)
 "mzR" = (
@@ -20789,15 +20783,13 @@
 	pixel_x = 25;
 	specialfunctions = 4
 	},
-/obj/structure/mirror{
-	pixel_y = -31
-	},
 /obj/machinery/light/floor{
 	alpha = 0;
 	invisibility = 100;
 	light_range = 10;
 	nightshift_light_power = 10
 	},
+/obj/structure/mirror/directional/south,
 /turf/open/floor/wood,
 /area/centcom/holding/cafe)
 "qoG" = (
@@ -25694,9 +25686,7 @@
 /turf/open/floor/iron/smooth_large,
 /area/centcom/castor/engineering/atmospherics)
 "uXf" = (
-/obj/structure/mirror{
-	pixel_y = 32
-	},
+/obj/structure/mirror/directional/north,
 /obj/structure/toilet{
 	pixel_y = 14
 	},
@@ -26236,11 +26226,9 @@
 /turf/open/floor/stone,
 /area/centcom/central_command_areas/evacuation/ship)
 "vsW" = (
+/obj/structure/mirror/directional/north,
 /obj/structure/toilet{
 	pixel_y = 14
-	},
-/obj/structure/mirror{
-	pixel_y = 32
 	},
 /turf/open/indestructible/bathroom,
 /area/centcom/holding/cafedorms)

--- a/_maps/map_files/generic/CentCom_oculis.dmm
+++ b/_maps/map_files/generic/CentCom_oculis.dmm
@@ -2265,9 +2265,7 @@
 	},
 /area/centcom/holding/cafepark)
 "aAX" = (
-/obj/structure/mirror{
-	pixel_y = 32
-	},
+/obj/structure/mirror/directional/north,
 /turf/open/indestructible/carpet,
 /area/centcom/holding/cafe)
 "aBa" = (


### PR DESCRIPTION

## About The Pull Request
Replaces the ghost cafe mirrors with proper directional ones.
## Why it's Good for the Game
Now the mirrors won't reflect you as being upside-down and backwards.
## Proof of Testing
<details>
<summary>Screenshots/Videos</summary>

### Before:
<img width="279" height="280" alt="image" src="https://github.com/user-attachments/assets/af71b68a-20b5-433e-a3cb-2bc144b326bf" />

### After: 
<img width="400" height="375" alt="Screenshot 2026-07-11 090733" src="https://github.com/user-attachments/assets/a59fdd1c-08b6-4634-9a53-d3d46c714dd6" />
</details>

## Changelog
:cl:
fix: Fixed some of the mirrors in the ghost cafe showing you upside-down and backwards.
map: Changed the ghost cafe mirrors to directional types.
/:cl:
