### PR TITLE
Removes russian revolvers replacing themselves with renpards on mapload and instead just removes them

### DIFF
--- a/_maps/RandomRuins/LavaRuins/lavaland_surface_greed.dmm
+++ b/_maps/RandomRuins/LavaRuins/lavaland_surface_greed.dmm
@@ -10,7 +10,9 @@
 /area/lavaland/surface/outdoors)
 "e" = (
 /obj/structure/table/wood/poker,
-/obj/item/gun/ballistic/revolver/russian/soul,
+/obj/item/stack/spacecash/c1000{
+	amount = 2
+	},
 /turf/open/floor/carpet,
 /area/ruin/powered/greed)
 "f" = (

--- a/_maps/RandomZLevels/Academy.dmm
+++ b/_maps/RandomZLevels/Academy.dmm
@@ -601,12 +601,6 @@
 	},
 /turf/open/floor/iron,
 /area/awaymission/caves/academy)
-"dS" = (
-/obj/structure/table,
-/obj/item/gun/ballistic/revolver/russian,
-/obj/effect/turf_decal/tile/neutral/fourcorners,
-/turf/open/floor/iron/dark,
-/area/awaymission/caves/academy)
 "dT" = (
 /obj/item/stack/cable_coil,
 /turf/open/floor/iron,
@@ -12547,7 +12541,7 @@ Zc
 Zc
 Zc
 Zc
-dS
+iQ
 eD
 iQ
 eD

--- a/_maps/map_files/CatwalkStation/CatwalkStation_2023.dmm
+++ b/_maps/map_files/CatwalkStation/CatwalkStation_2023.dmm
@@ -16737,10 +16737,6 @@
 /area/station/security/warden)
 "etm" = (
 /obj/structure/table/reinforced,
-/obj/item/gun/ballistic/revolver/russian{
-	pixel_x = -2;
-	pixel_y = 3
-	},
 /turf/open/floor/glass/reinforced,
 /area/station/command/vault)
 "etp" = (
@@ -63397,10 +63393,6 @@
 /area/station/service/abandoned_gambling_den)
 "qRa" = (
 /obj/structure/table/wood,
-/obj/item/gun/ballistic/revolver/russian{
-	pixel_x = 2;
-	pixel_y = -2
-	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/wood,

--- a/_maps/map_files/IceBoxStation/IceBoxStation.dmm
+++ b/_maps/map_files/IceBoxStation/IceBoxStation.dmm
@@ -27467,7 +27467,6 @@
 /obj/item/clothing/head/costume/bearpelt,
 /obj/item/reagent_containers/cup/glass/drinkingglass/shotglass,
 /obj/item/reagent_containers/cup/glass/drinkingglass/shotglass,
-/obj/item/gun/ballistic/revolver/russian,
 /obj/item/ammo_box/speedloader/c357,
 /obj/item/reagent_containers/cup/glass/bottle/vodka/badminka,
 /obj/effect/turf_decal/bot_white/left,

--- a/_maps/map_files/MetaStation/MetaStation.dmm
+++ b/_maps/map_files/MetaStation/MetaStation.dmm
@@ -43824,7 +43824,6 @@
 /obj/item/card/id/advanced/silver/reaper,
 /obj/item/lazarus_injector,
 /obj/item/gun/energy/disabler,
-/obj/item/gun/ballistic/revolver/russian,
 /obj/item/ammo_box/speedloader/c357,
 /obj/item/clothing/neck/stethoscope,
 /obj/item/book{

--- a/_maps/map_files/NebulaStation/NebulaStation.dmm
+++ b/_maps/map_files/NebulaStation/NebulaStation.dmm
@@ -107146,10 +107146,6 @@
 "pMJ" = (
 /obj/item/chair/plastic,
 /obj/effect/decal/cleanable/blood/old,
-/obj/item/gun/ballistic/revolver/russian{
-	pixel_x = -12;
-	pixel_y = 6
-	},
 /turf/open/floor/plating,
 /area/station/maintenance/port/fore)
 "pMO" = (

--- a/_maps/map_files/Snowglobe/snowglobe.dmm
+++ b/_maps/map_files/Snowglobe/snowglobe.dmm
@@ -24877,13 +24877,6 @@
 /obj/structure/fireplace,
 /turf/open/floor/stone,
 /area/station/commons/dorms/room6)
-"gHL" = (
-/obj/structure/table/wood/poker,
-/obj/item/gun/ballistic/revolver/russian{
-	pixel_y = 10
-	},
-/turf/open/floor/plating,
-/area/station/maintenance/bloodcasino)
 "gHN" = (
 /turf/closed/wall/r_wall,
 /area/station/science/explab)
@@ -191844,7 +191837,7 @@ bZa
 fYD
 hwL
 tzO
-gHL
+tzO
 qfu
 dwS
 xiy

--- a/_maps/map_files/VoidRaptor/VoidRaptor.dmm
+++ b/_maps/map_files/VoidRaptor/VoidRaptor.dmm
@@ -26960,7 +26960,6 @@
 /obj/item/card/id/advanced/silver/reaper,
 /obj/item/lazarus_injector,
 /obj/item/gun/energy/disabler,
-/obj/item/gun/ballistic/revolver/russian,
 /obj/item/ammo_box/speedloader/c357,
 /obj/item/clothing/neck/stethoscope,
 /obj/item/book{

--- a/_maps/map_files/generic/CentCom_oculis.dmm
+++ b/_maps/map_files/generic/CentCom_oculis.dmm
@@ -14167,7 +14167,6 @@
 /obj/item/card/id/advanced/silver/reaper,
 /obj/item/lazarus_injector,
 /obj/item/gun/energy/disabler,
-/obj/item/gun/ballistic/revolver/russian,
 /obj/item/ammo_box/speedloader/c357,
 /obj/item/clothing/neck/stethoscope,
 /obj/item/book{

--- a/_maps/map_files/oceanpubby/oceanpubby.dmm
+++ b/_maps/map_files/oceanpubby/oceanpubby.dmm
@@ -12157,9 +12157,6 @@
 /turf/open/floor/iron/dark,
 /area/station/security/prison)
 "bco" = (
-/obj/item/gun/ballistic/revolver/russian{
-	pixel_y = 16
-	},
 /obj/item/storage/box/matches{
 	pixel_x = -3;
 	pixel_y = 5

--- a/_maps/map_files/tramstation/tramstation.dmm
+++ b/_maps/map_files/tramstation/tramstation.dmm
@@ -45413,7 +45413,6 @@
 "oQO" = (
 /obj/structure/safe/vault,
 /obj/item/clothing/head/costume/bearpelt,
-/obj/item/gun/ballistic/revolver/russian,
 /obj/item/ammo_box/speedloader/c357,
 /obj/effect/turf_decal/bot_white/left,
 /obj/effect/turf_decal/tile/neutral/fourcorners,

--- a/_maps/map_files/wawastation/wawastation.dmm
+++ b/_maps/map_files/wawastation/wawastation.dmm
@@ -34302,7 +34302,6 @@
 /area/station/science/robotics/mechbay)
 "lOE" = (
 /obj/structure/table/wood,
-/obj/item/gun/ballistic/revolver/russian,
 /turf/open/floor/wood,
 /area/station/commons/lounge)
 "lPe" = (

--- a/_maps/shuttles/emergency/emergency_luxury.dmm
+++ b/_maps/shuttles/emergency/emergency_luxury.dmm
@@ -805,11 +805,6 @@
 /obj/structure/window/reinforced/spawner/directional/east,
 /turf/open/floor/iron,
 /area/shuttle/escape)
-"Fl" = (
-/obj/structure/table/wood/fancy/black,
-/obj/item/gun/ballistic/revolver/russian,
-/turf/open/floor/carpet/green,
-/area/shuttle/escape/luxury)
 "Fq" = (
 /obj/structure/bed,
 /obj/effect/decal/cleanable/dirt,
@@ -1555,7 +1550,7 @@ Gq
 xV
 DK
 Ky
-Fl
+DK
 yB
 jJ
 We

--- a/code/game/objects/effects/spawners/random/entertainment.dm
+++ b/code/game/objects/effects/spawners/random/entertainment.dm
@@ -53,7 +53,7 @@
 	name = "gambling valuables spawner"
 	icon_state = "dice"
 	loot = list(
-		/obj/item/gun/ballistic/revolver/russian = 5,
+		// /obj/item/gun/ballistic/revolver/russian = 5, // OCULIS EDIT REMOVAL
 		/obj/item/clothing/head/costume/ushanka = 3,
 		/obj/effect/spawner/random/entertainment/coin = 3,
 		/obj/effect/spawner/random/entertainment/money = 3,

--- a/modular_nova/master_files/code/modules/projectiles/guns/ballistic/revolver.dm
+++ b/modular_nova/master_files/code/modules/projectiles/guns/ballistic/revolver.dm
@@ -1,21 +1,15 @@
 /obj/item/gun/ballistic/revolver/c38
 	w_class = WEIGHT_CLASS_SMALL // concealed carry blickinator
 
+/* // OCULIS EDIT REMOVAL START
 /obj/item/gun/ballistic/revolver/russian/Initialize(mapload)
-	/* // OCULIS EDIT REMOVAL START
 	. = ..()
 	if(mapload)
 		new /obj/item/gun/ballistic/revolver/sol(get_turf(src))
 		return INITIALIZE_HINT_QDEL
-	*/ // OCULIS EDIT REMOVAL END
-	// OCULIS EDIT ADDITION START
-	if(mapload)
-		return INITIALIZE_HINT_QDEL // Don't bother initalizing it, we're deleting it anyways and replacing it with nothing
-	else
-		return ..()
-	// OCULIS EDIT ADDITION END
 
 /obj/item/gun/ballistic/revolver/russian/soul/Initialize(mapload)
 	. = ..()
 	if (mapload)
 		new /obj/item/stack/spacecash/c1000{amount = 2}(get_turf(src)) //done for the relic since it can be sold for 4-5k
+*/ // OCULIS EDIT REMOVAL END

--- a/modular_nova/master_files/code/modules/projectiles/guns/ballistic/revolver.dm
+++ b/modular_nova/master_files/code/modules/projectiles/guns/ballistic/revolver.dm
@@ -2,10 +2,18 @@
 	w_class = WEIGHT_CLASS_SMALL // concealed carry blickinator
 
 /obj/item/gun/ballistic/revolver/russian/Initialize(mapload)
+	/* // OCULIS EDIT REMOVAL START
 	. = ..()
 	if(mapload)
-		// new /obj/item/gun/ballistic/revolver/sol(get_turf(src)) // OCULIS EDIT REMOVAL
+		new /obj/item/gun/ballistic/revolver/sol(get_turf(src))
 		return INITIALIZE_HINT_QDEL
+	*/ // OCULIS EDIT REMOVAL END
+	// OCULIS EDIT ADDITION START
+	if(mapload)
+		return INITIALIZE_HINT_QDEL // Don't bother initalizing it, we're deleting it anyways and replacing it with nothing
+	else
+		return ..()
+	// OCULIS EDIT ADDITION END
 
 /obj/item/gun/ballistic/revolver/russian/soul/Initialize(mapload)
 	. = ..()

--- a/modular_nova/master_files/code/modules/projectiles/guns/ballistic/revolver.dm
+++ b/modular_nova/master_files/code/modules/projectiles/guns/ballistic/revolver.dm
@@ -4,7 +4,7 @@
 /obj/item/gun/ballistic/revolver/russian/Initialize(mapload)
 	. = ..()
 	if(mapload)
-		new /obj/item/gun/ballistic/revolver/sol(get_turf(src))
+		// new /obj/item/gun/ballistic/revolver/sol(get_turf(src)) // OCULIS EDIT REMOVAL
 		return INITIALIZE_HINT_QDEL
 
 /obj/item/gun/ballistic/revolver/russian/soul/Initialize(mapload)


### PR DESCRIPTION

## About The Pull Request
Changes russian revolvers to not spawn renpard revolvers on mapload, soul russian revolvers not to spawn money on mapload.
Removes russian revolvers from all maps and spawners, and replaces soul revolvers with money.
## Why it's Good for the Game
Russian revolvers don't fit Oculis. There's no reason to be spawning actual revolvers for the crew in place of russian revolvers.
## Proof of Testing
<details>
<summary>Screenshots/Videos</summary>
No Renpard spawned on top of the safe, no Renpard in the safe, no russian revolver in the safe.
<img width="2560" height="1380" alt="image" src="https://github.com/user-attachments/assets/e8fc8f96-f379-4753-aaa4-6c937efa7732" />
</details>

## Changelog
:cl:
del: Removed all spawns of russian revolvers. Soul russian revolvers have been replaced with 4k credits. Russian revolvers no longer replace themselves on mapload.
/:cl:
