### PR TITLE
Removes Fake Virus Because I'm A Hater

### DIFF
--- a/modular_nova/modules/ices_events/code/ICES_event_config.dm
+++ b/modular_nova/modules/ices_events/code/ICES_event_config.dm
@@ -196,7 +196,7 @@
 	intensity_restriction = TRUE
 
 /datum/round_event_control/fake_virus
-	max_occurrences = 1
+	max_occurrences = 0 // OCULIS EDIT CHANGE - ORIGINAL: max_occurrences = 1
 	weight = LOW_EVENT_FREQ
 
 /datum/round_event_control/heart_attack


### PR DESCRIPTION

## About The Pull Request
Removes Fake Virus from the event pool, while retaining the event in-code in case an admin wants to trigger it manually for... some reason.
## Why it's Good for the Game
Fake Virus is designed for a playspace where medical scrambles at the first mechanical sign of illness to start quarantining and treating. Unfortunately, more often than not, all this event does is awkwardly interrupt RP for 5 minutes. Players tend to ignore it, and the few times they don't they tend to be shooed away from medical and told it'll pass, given medical can't practically do anything to help. It's obtrusive, unengaging, and generally annoying, providing very little interaction for players or stimulation for the round at large. Let it die.
## Proof of Testing
<details>
<summary>Screenshots/Videos</summary>

I didn't :o) 

</details>

## Changelog
:cl:
del: Removes Fake Virus from the event pool.
/:cl:
