### PR TITLE
[EARLY PULL] Makes the synth centipede taur legs actually synthetic

### DIFF
--- a/modular_nova/modules/customization/modules/surgery/organs/taur_body.dm
+++ b/modular_nova/modules/customization/modules/surgery/organs/taur_body.dm
@@ -192,7 +192,7 @@
 	right_leg_name = "dozens of right legs"
 
 /obj/item/organ/taur_body/centipede/synth
-	organ_flags = parent_type::organ_flags | ORGAN_ROBOTIC
+	organ_flags = (parent_type::organ_flags | ORGAN_ROBOTIC) & ~ORGAN_ORGANIC & ~ORGAN_EDIBLE
 
 /obj/item/organ/taur_body/anthro
 	left_leg_name = null


### PR DESCRIPTION

## About The Pull Request
### Early pull of https://github.com/NovaSector/NovaSector/pull/7650
Removes the organic and edible flags from the synth centipede organ.
## Why it's Good for the Game
The legs are now properly treated as synthetic.
## Proof of Testing
<details>
<summary>Screenshots/Videos</summary>

Note the organ flags.
<img width="595" height="851" alt="Screenshot 2026-07-15 131646" src="https://github.com/user-attachments/assets/b951e178-9d33-457c-880a-03e6e44d4807" />
<img width="658" height="227" alt="Screenshot 2026-07-15 131812" src="https://github.com/user-attachments/assets/36255754-902f-4745-940f-b93014aefb3f" />
</details>

## Changelog
:cl:
fix: Fixed synth centipede taur legs not actually being fully synthetic.
/:cl:
