### PR TITLE
More portal storms

### DIFF
--- a/code/modules/events/portal_storm.dm
+++ b/code/modules/events/portal_storm.dm
@@ -31,6 +31,24 @@
 		/mob/living/basic/construct/wraith/hostile = 6,
 	)
 
+// OCULIS EDIT ADDITION START - MORE_PORTAL_STORMS
+/datum/round_event_control/portal_storm_lavaland
+	name = "Portal Storm: Lavaland"
+	typepath = /datum/round_event/portal_storm/lavaland
+	weight = 1
+	min_players = 15
+	earliest_start = 30 MINUTES
+	category = EVENT_CATEGORY_ENTITIES
+	description = "Lavaland monsters pour out of portals."
+
+/datum/round_event/portal_storm/lavaland
+	boss_types = list(/mob/living/basic/mining/hivelord = 2)
+	hostile_types = list(
+		/mob/living/basic/mining/brimdemon = 3,
+		/mob/living/basic/mining/lobstrosity/lava = 5,
+	)
+// OCULIS EDIT ADDITION END
+
 /datum/round_event/portal_storm
 	start_when = 7
 	end_when = 999

--- a/code/modules/events/portal_storm.dm
+++ b/code/modules/events/portal_storm.dm
@@ -32,21 +32,20 @@
 	)
 
 // OCULIS EDIT ADDITION START - MORE_PORTAL_STORMS
-/datum/round_event_control/portal_storm_lavaland
-	name = "Portal Storm: Lavaland"
-	typepath = /datum/round_event/portal_storm/lavaland
+/datum/round_event_control/portal_storm_xenomorph
+	name = "Portal Storm: Aliens"
+	typepath = /datum/round_event/portal_storm/xenomorph
 	weight = 1
 	min_players = 20
 	earliest_start = 30 MINUTES
 	category = EVENT_CATEGORY_ENTITIES
-	description = "Lavaland monsters pour out of portals."
+	description = "Xenomorphs pour out of portals."
 
-/datum/round_event/portal_storm/lavaland
-	boss_types = list(/mob/living/basic/mining/hivelord = 1)
+/datum/round_event/portal_storm/xenomorph
+	boss_types = list(/mob/living/basic/alien/queen = 1)
 	hostile_types = list(
-		/mob/living/basic/mining/brimdemon = 2,
-		/mob/living/basic/mining/lobstrosity/lava = 4,
-		/mob/living/basic/mining/legion = 2,
+		/mob/living/basic/alien = 7,
+		/mob/living/basic/alien/drone = 5,
 	)
 // OCULIS EDIT ADDITION END
 

--- a/code/modules/events/portal_storm.dm
+++ b/code/modules/events/portal_storm.dm
@@ -41,12 +41,13 @@
 	earliest_start = 30 MINUTES
 	category = EVENT_CATEGORY_ENTITIES
 	description = "Netherworld creatures pour out of portals."
+	intensity_restriction = TRUE
 
 /datum/round_event/portal_storm/netherworld
-	boss_types = list(/mob/living/basic/migo = 4)
+	boss_types = list(/mob/living/basic/migo = 5)
 	hostile_types = list(
-		/mob/living/basic/creature/hatchling = 9,
-		/mob/living/basic/creature = 7,
+		/mob/living/basic/creature/hatchling = 12,
+		/mob/living/basic/creature = 8,
 	)
 // OCULIS EDIT ADDITION END
 

--- a/code/modules/events/portal_storm.dm
+++ b/code/modules/events/portal_storm.dm
@@ -31,42 +31,6 @@
 		/mob/living/basic/construct/wraith/hostile = 6,
 	)
 
-// OCULIS EDIT ADDITION START - MORE_PORTAL_STORMS
-
-/datum/round_event_control/portal_storm_netherworld
-	name = "Portal Storm: Netherworld"
-	typepath = /datum/round_event/portal_storm/netherworld
-	weight = 1
-	min_players = 15
-	earliest_start = 30 MINUTES
-	category = EVENT_CATEGORY_ENTITIES
-	description = "Netherworld creatures pour out of portals."
-	intensity_restriction = TRUE
-
-/datum/round_event/portal_storm/netherworld
-	boss_types = list(/mob/living/basic/migo = 5)
-	hostile_types = list(
-		/mob/living/basic/creature/hatchling = 12,
-		/mob/living/basic/creature = 8,
-	)
-
-/datum/round_event_control/portal_storm_pirates //Pirate storm meant to be similar but stronger than the syndicate verson, at the cost of an ICES credit. More enemies, more of which are ranged.
-	name = "Portal Storm: Pirates"
-	typepath = /datum/round_event/portal_storm/pirates
-	weight = 1
-	min_players = 20
-	earliest_start = 1 HOURS
-	category = EVENT_CATEGORY_ENTITIES
-	description = "Space pirates pour out of portals."
-	intensity_restriction = TRUE
-
-/datum/round_event/portal_storm/pirates
-	boss_types = list(/mob/living/basic/trooper/pirate/ranged/space = 6)
-	hostile_types = list(
-		/mob/living/basic/trooper/pirate/melee/space = 10,
-	)
-// OCULIS EDIT ADDITION END
-
 /datum/round_event/portal_storm
 	start_when = 7
 	end_when = 999

--- a/code/modules/events/portal_storm.dm
+++ b/code/modules/events/portal_storm.dm
@@ -52,7 +52,7 @@
 	name = "Portal Storm: Netherworld"
 	typepath = /datum/round_event/portal_storm/netherworld
 	weight = 1
-	min_players = 20
+	min_players = 15
 	earliest_start = 30 MINUTES
 	category = EVENT_CATEGORY_ENTITIES
 	description = "Netherworld creatures pour out of portals."

--- a/code/modules/events/portal_storm.dm
+++ b/code/modules/events/portal_storm.dm
@@ -36,16 +36,16 @@
 	name = "Portal Storm: Lavaland"
 	typepath = /datum/round_event/portal_storm/lavaland
 	weight = 1
-	min_players = 15
+	min_players = 20
 	earliest_start = 30 MINUTES
 	category = EVENT_CATEGORY_ENTITIES
 	description = "Lavaland monsters pour out of portals."
 
 /datum/round_event/portal_storm/lavaland
-	boss_types = list(/mob/living/basic/mining/hivelord = 2)
+	boss_types = list(/mob/living/basic/mining/hivelord = 1)
 	hostile_types = list(
-		/mob/living/basic/mining/brimdemon = 3,
-		/mob/living/basic/mining/lobstrosity/lava = 5,
+		/mob/living/basic/mining/brimdemon = 2,
+		/mob/living/basic/mining/lobstrosity/lava = 4,
 		/mob/living/basic/mining/legion = 2,
 	)
 // OCULIS EDIT ADDITION END

--- a/code/modules/events/portal_storm.dm
+++ b/code/modules/events/portal_storm.dm
@@ -47,6 +47,22 @@
 		/mob/living/basic/alien = 7,
 		/mob/living/basic/alien/drone = 5,
 	)
+
+/datum/round_event_control/portal_storm_netherworld
+	name = "Portal Storm: Netherworld"
+	typepath = /datum/round_event/portal_storm/netherworld
+	weight = 1
+	min_players = 20
+	earliest_start = 30 MINUTES
+	category = EVENT_CATEGORY_ENTITIES
+	description = "Netherworld creatures pour out of portals."
+
+/datum/round_event/portal_storm/netherworld
+	boss_types = list(/mob/living/basic/migo = 4)
+	hostile_types = list(
+		/mob/living/basic/creature/hatchling = 9,
+		/mob/living/basic/creature = 7,
+	)
 // OCULIS EDIT ADDITION END
 
 /datum/round_event/portal_storm

--- a/code/modules/events/portal_storm.dm
+++ b/code/modules/events/portal_storm.dm
@@ -32,21 +32,6 @@
 	)
 
 // OCULIS EDIT ADDITION START - MORE_PORTAL_STORMS
-/datum/round_event_control/portal_storm_xenomorph
-	name = "Portal Storm: Aliens"
-	typepath = /datum/round_event/portal_storm/xenomorph
-	weight = 1
-	min_players = 20
-	earliest_start = 30 MINUTES
-	category = EVENT_CATEGORY_ENTITIES
-	description = "Xenomorphs pour out of portals."
-
-/datum/round_event/portal_storm/xenomorph
-	boss_types = list(/mob/living/basic/alien/queen = 1)
-	hostile_types = list(
-		/mob/living/basic/alien = 7,
-		/mob/living/basic/alien/drone = 5,
-	)
 
 /datum/round_event_control/portal_storm_netherworld
 	name = "Portal Storm: Netherworld"

--- a/code/modules/events/portal_storm.dm
+++ b/code/modules/events/portal_storm.dm
@@ -46,6 +46,7 @@
 	hostile_types = list(
 		/mob/living/basic/mining/brimdemon = 3,
 		/mob/living/basic/mining/lobstrosity/lava = 5,
+		/mob/living/basic/mining/legion = 2,
 	)
 // OCULIS EDIT ADDITION END
 

--- a/code/modules/events/portal_storm.dm
+++ b/code/modules/events/portal_storm.dm
@@ -49,6 +49,22 @@
 		/mob/living/basic/creature/hatchling = 12,
 		/mob/living/basic/creature = 8,
 	)
+
+/datum/round_event_control/portal_storm_pirates //Pirate storm meant to be similar but stronger than the syndicate verson, at the cost of an ICES credit. More enemies, more of which are ranged.
+	name = "Portal Storm: Pirates"
+	typepath = /datum/round_event/portal_storm/pirates
+	weight = 1
+	min_players = 20
+	earliest_start = 1 HOURS
+	category = EVENT_CATEGORY_ENTITIES
+	description = "Space pirates pour out of portals."
+	intensity_restriction = TRUE
+
+/datum/round_event/portal_storm/pirates
+	boss_types = list(/mob/living/basic/trooper/pirate/ranged/space = 6)
+	hostile_types = list(
+		/mob/living/basic/trooper/pirate/melee/space = 10,
+	)
 // OCULIS EDIT ADDITION END
 
 /datum/round_event/portal_storm

--- a/modular_oculis/modules/more_portal_storms/code/extrastorms.dm
+++ b/modular_oculis/modules/more_portal_storms/code/extrastorms.dm
@@ -1,0 +1,32 @@
+/datum/round_event_control/portal_storm_netherworld
+	name = "Portal Storm: Netherworld"
+	typepath = /datum/round_event/portal_storm/netherworld
+	weight = 1
+	min_players = 15
+	earliest_start = 30 MINUTES
+	category = EVENT_CATEGORY_ENTITIES
+	description = "Netherworld creatures pour out of portals."
+	intensity_restriction = TRUE
+
+/datum/round_event/portal_storm/netherworld
+	boss_types = list(/mob/living/basic/migo = 5)
+	hostile_types = list(
+		/mob/living/basic/creature/hatchling = 12,
+		/mob/living/basic/creature = 8,
+	)
+
+/datum/round_event_control/portal_storm_pirates //Pirate storm meant to be similar but stronger than the syndicate verson, at the cost of an ICES credit. More enemies, more of which are ranged.
+	name = "Portal Storm: Pirates"
+	typepath = /datum/round_event/portal_storm/pirates
+	weight = 1
+	min_players = 20
+	earliest_start = 1 HOURS
+	category = EVENT_CATEGORY_ENTITIES
+	description = "Space pirates pour out of portals."
+	intensity_restriction = TRUE
+
+/datum/round_event/portal_storm/pirates
+	boss_types = list(/mob/living/basic/trooper/pirate/ranged/space = 6)
+	hostile_types = list(
+		/mob/living/basic/trooper/pirate/melee/space = 10,
+	)

--- a/modular_oculis/modules/more_portal_storms/readme.md
+++ b/modular_oculis/modules/more_portal_storms/readme.md
@@ -1,0 +1,44 @@
+<!-- This should be copy-pasted into the root of your module folder as readme.md -->
+
+https://github.com/Monkestation/OculisStation/pull/<!--PR Number-->
+
+## \<More Portal Storms> <!--Title of your addition.-->
+
+Module ID: MORE_PORTAL_STORMS <!-- Uppercase, UNDERSCORE_CONNECTED name of your module, that you use to mark files. This is so people can case-sensitive search for your edits, if any. -->
+
+### Description:
+
+Adds more variants to the portal storm event, each more difficult at the cost of an ICES credit.
+
+### TG Proc/File Changes:
+
+- N/A
+<!-- If you edited any core procs, you should list them here. You should specify the files and procs you changed.
+E.g:
+- `code/modules/mob/living.dm`: `proc/overriden_proc`, `var/overriden_var`
+  -->
+
+### Modular Overrides:
+
+- N/A
+<!-- If you added a new modular override (file or code-wise) for your module, you should list it here. Code files should specify what procs they changed, in case of multiple modules using the same file.
+E.g:
+- `modular_oculis/master_files/sound/my_cool_sound.ogg`
+- `modular_oculis/master_files/code/my_modular_override.dm`: `proc/overriden_proc`, `var/overriden_var`
+  -->
+
+### Defines:
+
+- N/A
+<!-- If you needed to add any defines, mention the files you added those defines in, along with the name of the defines. -->
+
+### Included files that are not contained in this module:
+
+- N/A
+<!-- Likewise, be it a non-modular file or a modular one that's not contained within the folder belonging to this specific module, it should be mentioned here. Good examples are icons or sounds that are used between multiple modules, or other such edge-cases. -->
+
+### Credits:
+
+Keygenpie - Programmer
+
+<!-- Here go the credits to you, dear coder, and in case of collaborative work or ports, credits to the original source of the code. -->

--- a/tgstation.dme
+++ b/tgstation.dme
@@ -10300,6 +10300,7 @@
 #include "modular_oculis\modules\mod_saddle\module.dm"
 #include "modular_oculis\modules\modular_vending\code\clothing.dm"
 #include "modular_oculis\modules\modular_vending\code\vending.dm"
+#include "modular_oculis\modules\more_portal_storms\code\extrastorms.dm"
 #include "modular_oculis\modules\pets\code\shark.dm"
 #include "modular_oculis\modules\plexora\code\_plexora.dm"
 #include "modular_oculis\modules\plexora\code\config.dm"


### PR DESCRIPTION

## About The Pull Request

This pull request adds two more variants to the portal storm event; space pirates and netherworld creatures.

## Why it's Good for the Game

The portal storm event, while theoretically threatening, is entirely underwhelming in practice. Its lack of variety makes it non-threatening and generally uninteresting - in my playtime, it has come across as "oh, it's the constructs or maybe sometimes the syndies, whatever." Adding two new variants should not only add gameplay variation, but also make the event more unpredictable, and thus, threatening.

## Proof of Testing

<details>
<summary>Screenshots/Videos</summary>

Some creatures where they shouldn't be after a portal storm in the test build
<img width="787" height="356" alt="image" src="https://github.com/user-attachments/assets/6fabcf5e-a0e9-4a93-b921-0ddf1c68d229" />

And, some space pirates, lurking about
<img width="755" height="345" alt="image" src="https://github.com/user-attachments/assets/c82922a0-27ff-4309-9946-8d8fadea9e4e" />

Proof of successful event functionality in the chat 
<img width="476" height="184" alt="image" src="https://github.com/user-attachments/assets/b8dec268-b951-4722-83d9-bf30d7d117b5" />

</details>

## Changelog
:cl:
add: New space pirate portal-storm variant
add: New netherworld portal-storm variant
/:cl:
