### PR TITLE
Deletes a line of dialogue from Spraytan overdosing that breaks rule B2

### DIFF
--- a/code/modules/reagents/chemistry/reagents/other_reagents.dm
+++ b/code/modules/reagents/chemistry/reagents/other_reagents.dm
@@ -658,7 +658,7 @@
 			else
 				affected_mob.visible_message("<b>[affected_mob]</b> flexes [affected_mob.p_their()] arms.")
 	if(SPT_PROB(5, seconds_per_tick))
-		affected_mob.say(pick("Shit was SO cash.", "You are everything bad in the world.", "What sports do you play, other than 'jack off to naked drawn Japanese people?'", "Don???t be a stranger. Just hit me with your best shot.", "My name is John and I hate every single one of you."), forced = /datum/reagent/spraytan)
+		affected_mob.say(pick("Shit was SO cash.", "You are everything bad in the world.", "Don???t be a stranger. Just hit me with your best shot.", "My name is John and I hate every single one of you."), forced = /datum/reagent/spraytan)
 
 #define MUT_MSG_IMMEDIATE 1
 #define MUT_MSG_EXTENDED 2


### PR DESCRIPTION

## About The Pull Request
Title.
I didn't put a code-comment on the deleted line due to the fact that we wouldn't apply it to any other code like this, as far as I'm concerned.
## Why it's Good for the Game
Title.
## Proof of Testing
One line change.
<details>
<summary>Screenshots/Videos</summary>

</details>

## Changelog
:cl:
del: Deletes a rule-breaking line of dialogue from spraytan overdose.
/:cl:
