### PR TITLE
Removes DRONE duffelbag slowdown

### DIFF
--- a/code/game/objects/items/storage/dufflebags.dm
+++ b/code/game/objects/items/storage/dufflebags.dm
@@ -216,6 +216,7 @@
 	icon_state = "duffel-drone"
 	inhand_icon_state = "duffel-drone"
 	resistance_flags = FIRE_PROOF
+	zip_slowdown = 0
 
 /obj/item/storage/backpack/duffelbag/drone/PopulateContents()
 	new /obj/item/screwdriver(src)


### PR DESCRIPTION

## About The Pull Request
This PR removes the slowdown from unzipped drone duffel bags. Please don't abuse this as a non-drone, I'd rather not have to make something preventing non-drones from using it.
## Why it's Good for the Game
fixes https://github.com/Monkestation/OculisStation/issues/322
Reasoning found in the above issue, it's been open for a month and no comments have been made. Feel free to comment if you don't agree, of course.
## Proof of Testing
If you need me to make a video I will, but I tested it unzipped and zipped. Seems like the same speed, feels like the right speed.
<details>
<summary>Screenshots/Videos</summary>
<img width="402" height="588" alt="image" src="https://github.com/user-attachments/assets/b99b8d0c-69cd-4216-a07c-4a3f0d2da6b4" />
</details>

## Changelog
:cl:
balance: Removed unzipped drone duffelbag slowdown
/:cl:
