### PR TITLE
changes so positive_traits.dm doesn't call the planet a "ice moon" when it's clearly not a ice moon

### DIFF
--- a/code/datums/station_traits/positive_traits.dm
+++ b/code/datums/station_traits/positive_traits.dm
@@ -373,7 +373,7 @@
 
 /datum/station_trait/bright_day
 	name = "Bright Day"
-	report_message = "The stars shine bright and the clouds are scarcer than usual. It's a bright day here on the Ice Moon's surface."
+	report_message = "The stars shine bright and the clouds are scarcer than usual. It's a bright day here on the surface."
 	trait_type = STATION_TRAIT_POSITIVE
 	weight = 5
 	show_in_report = TRUE


### PR DESCRIPTION

## About The Pull Request
YOU DONT UNDERSTAND THIS IS A MAJOR FIX.
## Why it's Good for the Game
cures my IMMERSION BREAKING. also it helps that the report doesn't always assume that it's a ice moon.
## Proof of Testing
yes i compiled a one-line change ....
<details>
<summary>Screenshots/Videos</summary>

</details>

## Changelog
:cl:
spellcheck: In round-start reports, Nanotrasen will no longer call ocean planets a "ice moon".
/:cl:
