### PR TITLE
Adds a new emote: *roll2d6

### DIFF
--- a/modular_nova/modules/emote_panel/code/emote_panel.dm
+++ b/modular_nova/modules/emote_panel/code/emote_panel.dm
@@ -9,6 +9,7 @@
 		/mob/proc/emote_flip,
 		/mob/proc/emote_spin,
 		/mob/proc/emote_rolld20,
+		/mob/proc/emote_roll2d6, // OCULIS EDIT ADDITION
 	)
 	all_emotes += mob_emotes
 

--- a/modular_oculis/modules/emotes/code/emotes.dm
+++ b/modular_oculis/modules/emotes/code/emotes.dm
@@ -19,3 +19,19 @@
 	if(tail)
 		return ..()
 	return FALSE
+
+/mob/proc/emote_roll2d6()
+	set name = "| Roll 2d6 |"
+	set category = "Emotes"
+	usr.emote("roll2d6", intentional = TRUE)
+
+/datum/emote/roll2d6
+	key = "roll2d6"
+	affected_by_pitch = FALSE
+
+/datum/emote/roll2d6/run_emote(mob/user, params, type_override, intentional)
+	. = ..()
+	var/roll1 = roll(6)
+	var/roll2 = roll(6)
+	var/result = roll1 + roll2
+	user.client?.looc_message("[user] rolls 2d6 and gets [roll1]+[roll2]=[result].")


### PR DESCRIPTION

## About The Pull Request
Adds a new emote, *roll2d6. It's like *rolld20, but instead it rolls 2d6. It outputs "[user] rolls 2d6 and gets [roll1]+[roll2]=[result]." into LOOC.
## Why it's Good for the Game
I'd like a built-in roll emote that's more consistent than a d20, and I assume other people would as well. 2d6 seemed like a good choice to make it clearly different from the d20 rolls, and I thought Disco Elysium's standard roll would fit since there's already the various Disco Elysium-esque items already in the game.
## Proof of Testing
<details>
<summary>Screenshots/Videos</summary>
<img width="592" height="156" alt="image" src="https://github.com/user-attachments/assets/b9e87d7b-4485-4c9f-a69f-ff8a2d57e515" />
</details>

## Changelog
:cl:
add: Added a new emote: *roll2d6. It outputs "[user] rolls 2d6 and gets [roll1]+[roll2]=[result]."
/:cl:
