### PR TITLE
Moving a crate past a pixelshifted person will no longer cause their sprite to move up.

### DIFF
--- a/code/datums/elements/elevation.dm
+++ b/code/datums/elements/elevation.dm
@@ -116,7 +116,11 @@
 	ADD_TRAIT(target, TRAIT_ELEVATED_TURF, ELEVATION_SOURCE(src))
 
 	for(var/mob/living/living in target)
-		register_new_mob(living)
+		// register_new_mob(living) // OCULIS EDIT REMOVAL
+		// OCULIS EDIT ADDITION START
+		if(!living.has_offset(/datum/component/pixel_shift))
+			register_new_mob(living)
+		// OCULIS EDIT ADDITION END
 
 /datum/element/elevation_core/Detach(datum/source)
 	/**


### PR DESCRIPTION

## About The Pull Request
See title

## Why it's Good for the Game
bugfix good

## Proof of Testing
<details>
<summary>Screenshots/Vid

https://github.com/user-attachments/assets/b4d13a22-6847-4e85-b910-b6688ba3ca1c

</summary>

</details>

## Changelog
:cl:
fix: Moving a crate past a pixelshifted person will no longer cause their sprite to move up.
/:cl:
