### PR TITLE
Fixes Wawastation's Robotics Automapper (aka: the great "uh oh!" automapper pr)

### DIFF
--- a/_maps/nova/automapper/automapper_config.toml
+++ b/_maps/nova/automapper/automapper_config.toml
@@ -916,7 +916,7 @@ trait_name = "Station"
 map_files = ["wawastation_robotics_medical_records.dmm"]
 directory = "_maps/oculis/automapper/templates/wawastation/"
 required_map = "wawastation.dmm"
-coordinates = [113, 106, 1]
+coordinates = [133, 106, 1]
 trait_name = "Station"
 
 # Oculis - Kilostation Explorer Spawns


### PR DESCRIPTION

## About The Pull Request
hi! I fucked up. (but it wasn't that bad)
this fixes the robotics medical record console in Wawa. previously automapper was instructed to place it near the holodeck because of a one digit difference. whoops. mb. wont cook again
## Why it's Good for the Game
A medical record console doesn't spawn near the holodeck anymore!! Also automapper doesn't screw up anything anymore
## Proof of Testing
compiled and tested! photo below
<details>
<summary>Screenshots/Videos</summary>
<img width="488" height="418" alt="image" src="https://github.com/user-attachments/assets/209db96f-6254-49bf-8666-165bef8012a3" />
</details>

## Changelog
:cl:
fix: On Wawastation, the robotics medical records console now is placed in the right spot (robotics) instead of near the holodeck.
/:cl:
