### PR TITLE
Doubles Available Loadout Presets

### DIFF
--- a/code/__DEFINES/~nova_defines/loadouts.dm
+++ b/code/__DEFINES/~nova_defines/loadouts.dm
@@ -33,7 +33,7 @@
 
 // NOTE TO FUTURE CODERS: If you increase this to a huge number, please restrict the overall **amount** of items players can take,
 // if item count restrictions have been significantly increased. You will end up with massively bloated save sizes otherwise.
-#define LOADOUT_MAX_PRESETS 12
+#define LOADOUT_MAX_PRESETS 24 // OCULIS EDIT: this sign can't stop me because I can't read!!! ORIGINAL: #define LOADOUT_MAX_PRESETS 12
 #define LOADOUT_MAX_NAME_LENGTH 24
 
 /// Please add jobs here. It's cleaner using these.

--- a/tgui/packages/tgui/interfaces/PreferencesMenu/CharacterPreferences/loadout/index.tsx
+++ b/tgui/packages/tgui/interfaces/PreferencesMenu/CharacterPreferences/loadout/index.tsx
@@ -87,7 +87,7 @@ export function LoadoutPage(props) {
                         data.character_preferences.misc.loadout_lists.loadouts
                           .length
                       }{' '}
-                      of 12 total)
+                      of 24 total)
                     </Flex.Item>
                   )}
                   <Flex.Item ml="auto">


### PR DESCRIPTION

## About The Pull Request
Title
## Why it's Good for the Game

It is surprisingly easy to hit loadout cap on a character if they work two departments and have any off duty outfits. We have a frankly ridiculous number of character slots, so save file size evidently isn't as much of a concern as it used to be. If people want more loadouts, they'll cheese the system by making a 1:1 character. This saves the hassle. 

Most importantly: 
<img width="415" height="75" alt="image" src="https://github.com/user-attachments/assets/e66e5235-d208-412d-a79d-e0b199ec471e" />
## Proof of Testing
<details>
<summary>Screenshots/Videos</summary>

<img width="488" height="82" alt="image" src="https://github.com/user-attachments/assets/3e93301d-f470-4d8b-ad1c-07a61a005eec" />

</details>

## Changelog
:cl:
qol: Doubles the available loadout preset slots
/:cl:
