### PR TITLE
Fixes Social Anxiety block chance

### DIFF
--- a/code/datums/quirks/negative_quirks/social_anxiety.dm
+++ b/code/datums/quirks/negative_quirks/social_anxiety.dm
@@ -72,7 +72,7 @@
 		for(var/word in message_split)
 			if(prob(max(5, moodmod)) && word != message_split[1]) //Minimum 1/20 chance of filler
 				new_message += pick("uh,","erm,","um,")
-				if(prob(min(5, moodmod))) //Max 1 in 20 chance of cutoff after a successful filler roll, for 50% odds in a 15 word sentence
+				if(prob(min(5, moodmod) * speech_block_chance)) // OCULIS EDIT - Original: if(prob(min(5, moodmod))) | Fixes Social Anxiety speech block chance
 					quirk_holder.set_silence_if_lower(6 SECONDS)
 					to_chat(quirk_holder, span_danger("You feel self-conscious and stop talking. You need a moment to recover!"))
 					break

--- a/code/datums/quirks/negative_quirks/social_anxiety.dm
+++ b/code/datums/quirks/negative_quirks/social_anxiety.dm
@@ -79,7 +79,7 @@
 			new_message += word
 		message = jointext(new_message, " ")
 
-	if(prob(speech_block_chance)) //IRIS EDIT Original "if(prob(min(50, (0.50 * moodmod))))" | Applies block chance based on preference
+	if((speech_block_chance > 0) && prob(speech_block_chance)) // OCULIS EDIT original: if(prob(speech_block_chance)) | Fixes Social Anxiety block chance
 		if(dumb_thing)
 			to_chat(quirk_holder, span_userdanger("You think of a dumb thing you said a long time ago and scream internally."))
 			dumb_thing = FALSE //only once per life

--- a/code/datums/quirks/negative_quirks/social_anxiety.dm
+++ b/code/datums/quirks/negative_quirks/social_anxiety.dm
@@ -79,7 +79,7 @@
 			new_message += word
 		message = jointext(new_message, " ")
 
-	if((speech_block_chance > 0) && prob(speech_block_chance)) // OCULIS EDIT original: if(prob(speech_block_chance)) | Fixes Social Anxiety block chance
+	if(prob(speech_block_chance)) //IRIS EDIT Original "if(prob(min(50, (0.50 * moodmod))))" | Applies block chance based on preference
 		if(dumb_thing)
 			to_chat(quirk_holder, span_userdanger("You think of a dumb thing you said a long time ago and scream internally."))
 			dumb_thing = FALSE //only once per life


### PR DESCRIPTION

## About The Pull Request

Implements the block chance preference in the second previously hardcoded speech block roll.
## Why it's Good for the Game

People were setting the preference to zero and still getting blocked because of an oversight. This fixes that.
## Proof of Testing
<details>
<summary>Screenshots/Videos</summary>
<img width="421" height="566" alt="image" src="https://github.com/user-attachments/assets/de63cd63-a904-4975-b972-49edc5eb2145" />
</details>

## Changelog
:cl:
fix: Fixes Social Anxiety blocking speech even when the block chance is set to zero.
/:cl:
