### PR TITLE
Sets Particle weather default setting to False

### DIFF
--- a/code/modules/client/preferences/particle_weather.dm
+++ b/code/modules/client/preferences/particle_weather.dm
@@ -3,6 +3,7 @@
 	category = PREFERENCE_CATEGORY_GAME_PREFERENCES
 	savefile_key = "particle_weather"
 	savefile_identifier = PREFERENCE_PLAYER
+	default_value = FALSE // OCULIS EDIT ADDITION
 
 /datum/preference/toggle/particle_weather/apply_to_client(client/client, value)
 	for(var/atom/movable/screen/plane_master/rendering_plate/particle_weather/plane_master as anything in client.mob?.hud_used?.get_true_plane_masters(RENDER_PLANE_PARTICLE_WEATHER))


### PR DESCRIPTION

## About The Pull Request
should fix the weather issue by default

## Why it's Good for the Game
lag fix

## Proof of Testing
<details>
<summary>Screenshots/Videos</summary>

</details>

## Changelog
:cl:
qol: By default, particle weather is set to be disabled.
/:cl:
