### PR TITLE
Fixes crafting expanded .38 speedloaders

### DIFF
--- a/modular_nova/modules/modular_weapons/code/company_and_or_faction_based/nanotrasen_armories/conversion_kits.dm
+++ b/modular_nova/modules/modular_weapons/code/company_and_or_faction_based/nanotrasen_armories/conversion_kits.dm
@@ -117,7 +117,7 @@
 	tool_behaviors = list(TOOL_SCREWDRIVER)
 	time = 10 SECONDS
 	category = CAT_WEAPON_RANGED
-	crafting_flags = parent_type::crafting_flags | CRAFT_SKIP_MATERIALS_PARITY
+	crafting_flags = parent_type::crafting_flags | CRAFT_SKIP_MATERIALS_PARITY | CRAFT_COLLECT_REQUIREMENTS
 
 /datum/crafting_recipe/c38_speedloader_plus/New()
 	..()

--- a/modular_nova/modules/modular_weapons/code/company_and_or_faction_based/nanotrasen_armories/conversion_kits.dm
+++ b/modular_nova/modules/modular_weapons/code/company_and_or_faction_based/nanotrasen_armories/conversion_kits.dm
@@ -117,7 +117,7 @@
 	tool_behaviors = list(TOOL_SCREWDRIVER)
 	time = 10 SECONDS
 	category = CAT_WEAPON_RANGED
-	crafting_flags = parent_type::crafting_flags | CRAFT_SKIP_MATERIALS_PARITY | CRAFT_COLLECT_REQUIREMENTS
+	crafting_flags = parent_type::crafting_flags | CRAFT_SKIP_MATERIALS_PARITY | CRAFT_COLLECT_REQUIREMENTS // OCULIS EDIT, ORIGINAL: crafting_flags = parent_type::crafting_flags | CRAFT_SKIP_MATERIALS_PARITY
 
 /datum/crafting_recipe/c38_speedloader_plus/New()
 	..()


### PR DESCRIPTION

## About The Pull Request
Fixes crafting expanded .38 speedloaders, so you can craft them again.
Adds CRAFT_COLLECT_REQUIREMENTS to the crafting_flags.
## Why it's Good for the Game
Bugfix.
## Proof of Testing
I successfully crafted them on localhost.
<details>
<summary>Screenshots/Videos</summary>
<img width="875" height="900" alt="Screenshot 2026-08-17 155810" src="https://github.com/user-attachments/assets/ed49dc41-8675-43e2-b665-fb945316497b" />
</details>

## Changelog
:cl:
fix: Fixed expanded .38 speedloader crafting.
/:cl:
