### PR TITLE
Makes Inventory/Held/Equipped/Whatever Items Affected By Colour Filters

### DIFF
--- a/code/modules/client/client_colour.dm
+++ b/code/modules/client/client_colour.dm
@@ -129,7 +129,7 @@
 	if (isnull(hud_used))
 		return
 
-	for (var/atom/movable/screen/plane_master/game_plane as anything in hud_used.get_true_plane_masters(RENDER_PLANE_GAME))
+	for (var/atom/movable/screen/plane_master/game_plane as anything in ((hud_used.get_true_plane_masters(RENDER_PLANE_GAME)) + (hud_used.get_true_plane_masters(ABOVE_HUD_PLANE)))) // OCULIS EDIT CHANGE - ORIGINAL: for (var/atom/movable/screen/plane_master/game_plane as anything in hud_used.get_true_plane_masters(RENDER_PLANE_GAME))
 		for (var/filter_id in color_filter_store)
 			game_plane.remove_filter(filter_id)
 
@@ -139,7 +139,7 @@
 	for (var/list/color_filter as anything in applied_filters)
 		var/added_color = color_filter[CLIENT_COLOR_VALUE_INDEX]
 		var/filter_priority = color_filter[CLIENT_COLOR_PRIORITY_INDEX]
-		for (var/atom/movable/screen/plane_master/game_plane as anything in hud_used.get_true_plane_masters(RENDER_PLANE_GAME))
+		for (var/atom/movable/screen/plane_master/game_plane as anything in ((hud_used.get_true_plane_masters(RENDER_PLANE_GAME)) + (hud_used.get_true_plane_masters(ABOVE_HUD_PLANE)))) // OCULIS EDIT CHANGE - ORIGINAL: for (var/atom/movable/screen/plane_master/game_plane as anything in hud_used.get_true_plane_masters(RENDER_PLANE_GAME))
 			var/filter_id = "client_colour_[filter_priority]"
 			game_plane.add_filter(filter_id, filter_priority, added_color)
 			color_filter_store |= filter_id
@@ -152,7 +152,7 @@
 	if(anim_time <= -1)
 		return update_client_colour()
 
-	for (var/atom/movable/screen/plane_master/game_plane as anything in hud_used.get_true_plane_masters(RENDER_PLANE_GAME))
+	for (var/atom/movable/screen/plane_master/game_plane as anything in ((hud_used.get_true_plane_masters(RENDER_PLANE_GAME)) + (hud_used.get_true_plane_masters(ABOVE_HUD_PLANE)))) // OCULIS EDIT CHANGE - ORIGINAL: for (var/atom/movable/screen/plane_master/game_plane as anything in hud_used.get_true_plane_masters(RENDER_PLANE_GAME))
 		for (var/filter_id in color_filter_store)
 			game_plane.remove_filter(filter_id)
 
@@ -162,7 +162,7 @@
 	for (var/list/color_filter as anything in applied_filters)
 		var/added_color = color_filter[CLIENT_COLOR_VALUE_INDEX]
 		var/filter_priority = color_filter[CLIENT_COLOR_PRIORITY_INDEX]
-		for (var/atom/movable/screen/plane_master/game_plane as anything in hud_used.get_true_plane_masters(RENDER_PLANE_GAME))
+		for (var/atom/movable/screen/plane_master/game_plane as anything in ((hud_used.get_true_plane_masters(RENDER_PLANE_GAME)) + (hud_used.get_true_plane_masters(ABOVE_HUD_PLANE)))) // OCULIS EDIT CHANGE - ORIGINAL: for (var/atom/movable/screen/plane_master/game_plane as anything in hud_used.get_true_plane_masters(RENDER_PLANE_GAME))
 			var/filter_id = "client_colour_[filter_priority]"
 			game_plane.add_filter(filter_id, filter_priority, color_matrix_filter())
 			game_plane.transition_filter(filter_id, added_color, anim_time, anim_easing)


### PR DESCRIPTION

## About The Pull Request
Title! Adds ABOVE_HUD_PLANE to the list of planes impacted by colour filters. This also means some things like radials get caught in the crossfire, but that's probably fine.
## Why it's Good for the Game
Consistency. Presently, filters that impact a character's sight do not impact items they're interacting with. A blind character will have OOC knowledge of what color the item they're holding due to the inhand being rendered normally. This added consistency can help with player immersion. More to the point, it's always been a pet peeve of mine.
## Proof of Testing
<details>
<summary>Blind</summary>



<img width="2015" height="1440" alt="image" src="https://github.com/user-attachments/assets/4022bde6-8a04-41ea-a221-6fae7b514534" />


</details>


<details>
<summary>Colorblind (Deuteranopia)</summary>

<img width="2013" height="1440" alt="image" src="https://github.com/user-attachments/assets/820ecc02-624b-4b8c-ae57-5c08a2443e0a" />

</details>

## Changelog
:cl:
balance: colour filters now affect held/equipped/stored items in addition to the standard game plane
/:cl:
