### PR TITLE
Fixes affluent quirk spawning money out of thin air

### DIFF
--- a/modular_oculis/modules/quirks/code/affluent.dm
+++ b/modular_oculis/modules/quirks/code/affluent.dm
@@ -18,7 +18,7 @@
 /datum/quirk/affluent/proc/on_payday(datum/bank_account/source)
 	SIGNAL_HANDLER
 	var/datum/bank_account/department_account = SSeconomy.get_dep_account(source.account_job.paycheck_department)
-	if(!source.account_balance.transfer_money(department_account, payday_bonus))
-		source.bank_card_talk("ERROR: [event] aborted, departmental funds insufficient.")
+	if(!source.transfer_money(department_account, payday_bonus))
+		source.bank_card_talk("ERROR: Bonus payday aborted, departmental funds insufficient.")
 		return FALSE
 	source.bank_card_talk("Bonus processed, account now holds [source.account_balance] [MONEY_SYMBOL].")

--- a/modular_oculis/modules/quirks/code/affluent.dm
+++ b/modular_oculis/modules/quirks/code/affluent.dm
@@ -17,5 +17,8 @@
 
 /datum/quirk/affluent/proc/on_payday(datum/bank_account/source)
 	SIGNAL_HANDLER
-	source.account_balance += payday_bonus
+	var/datum/bank_account/department_account = SSeconomy.get_dep_account(source.account_job.paycheck_department)
+	if(!source.account_balance.transfer_money(department_account, payday_bonus))
+		source.bank_card_talk("ERROR: [event] aborted, departmental funds insufficient.")
+		return FALSE
 	source.bank_card_talk("Bonus processed, account now holds [source.account_balance] [MONEY_SYMBOL].")

--- a/modular_oculis/modules/quirks/code/affluent.dm
+++ b/modular_oculis/modules/quirks/code/affluent.dm
@@ -1,6 +1,6 @@
 /datum/quirk/affluent
 	name = "Affluent"
-	desc = "You've got a net worth and the extra credits to show for it; every time you get your wage, you get a bonus."
+	desc = "You've managed to negotiate a more favorable contract; every time you get your wage, you get a bonus."
 	value = 4
 	quirk_flags = QUIRK_HIDE_FROM_SCAN | QUIRK_EXCLUDES_GHOSTROLES
 	icon = FA_ICON_MONEY_CHECK_DOLLAR


### PR DESCRIPTION

## About The Pull Request
no longer do affluent people get Free Money

## Why it's Good for the Game
money has to come from somewhere

## Proof of Testing
<details>
<summary>Screenshots/Videos</summary>

</details>

## Changelog
:cl:
fix: Affluent quirk no longer spawns infinite money
/:cl:
