### PR TITLE
Support For Job-Specific MODules As Entombed (Plus Entombed Miner Buff!) 

### DIFF
--- a/modular_nova/master_files/code/modules/entombed_quirk/code/entombed.dm
+++ b/modular_nova/master_files/code/modules/entombed_quirk/code/entombed.dm
@@ -205,6 +205,7 @@
 	. = ..()
 	// quickly deploy it on roundstart. we can't do this in add_unique because that gets called in the preview screen, which overwrites people's loadout stuff in suit/shoes/gloves slot. very unfun for them
 	install_quirk_interaction_features() // have to do this here to ensure all traumas and the like from quirks are applied to our mob
+	install_job_relevant_features() // OCULIS EDIT ADDITION: supporting job-specific MODules
 	modsuit.quick_activation()
 
 /datum/quirk/equipping/entombed/remove()
@@ -238,6 +239,21 @@
 	if (human_holder.get_quirk(/datum/quirk/paraplegic))
 		var/obj/item/mod/module/anomaly_locked/antigrav/entombed/ambulator = new
 		modsuit.install(ambulator, human_holder)
+
+// OCULIS EDIT ADDITION START: supporting job-specific MODules
+
+/datum/quirk/equipping/entombed/proc/install_job_relevant_features()
+	// if a job needs more support than standard to function, add a module here!
+	if (!modsuit)
+		return
+	var/mob/living/carbon/human/human_holder = quirk_holder
+	if (human_holder && human_holder.mind && human_holder.mind.assigned_role)
+	// Entombed miners are practically forced to use a raptor due to the slowdown, not to mention the armor penalty. Ash accretion throws them a bone and makes it more tolerable to play
+		if (human_holder.mind.assigned_role.title == JOB_SHAFT_MINER)
+			var/obj/item/mod/module/ash_accretion/accretion = new
+			modsuit.install(accretion, human_holder)
+
+// OCULIS EDIT ADDITION END
 
 /datum/quirk_constant_data/entombed
 	associated_typepath = /datum/quirk/equipping/entombed


### PR DESCRIPTION

## About The Pull Request
Gives entombed miners the ash accretion MODule, allowing them to move at full speed on planetary tiles as well as circumstantially buffing their armor. Also adds code on the backend to support entombed players getting job-dependent MODs installed. 
## Why it's Good for the Game
While the entombed quirk is very flavored, it makes the game Miserable to play on certain roles. In particular, we've had a couple entombed players complain about how nonviable mining is. Giving them an ash accretion module should help mitigate that, as it was always intended to allow miners to function with a MOD regardless! 
## Proof of Testing
<details>
<summary>Screenshots/Videos</summary>

Miner spawn (also works with alt-titles, though that isn't seen here)

<img width="723" height="288" alt="image" src="https://github.com/user-attachments/assets/a365106b-e0f8-4d90-a70d-b4d581fb7ccc" />



Assistant (any role Not A Miner, really)

<img width="719" height="260" alt="image" src="https://github.com/user-attachments/assets/8c9627b1-2c70-4234-ac81-ecbbf3f5a2fe" />

</details>

## Changelog
:cl:
balance: entombed characters spawning as a shaft miner will now be given the ash accretion module, hopefully making it less of a miserable experience
/:cl:
