### PR TITLE
Adds hand labelers and mod paint kits to loadouts

### DIFF
--- a/modular_oculis/modules/loadouts/loadout_items/loadout_datum_pocket.dm
+++ b/modular_oculis/modules/loadouts/loadout_items/loadout_datum_pocket.dm
@@ -32,3 +32,11 @@
 	name = " SDSM-35"
 	item_path = /obj/item/tgui_book/manual/dsm
 	group = "Comfort"
+
+/datum/loadout_item/pocket_items/hand_labeler
+	name = "Hand Labeler"
+	item_path = /obj/item/hand_labeler
+
+/datum/loadout_item/pocket_items/mod_paint // it's actually normal sized but shhh
+	name = "MOD Paint Kit"
+	item_path = /obj/item/mod/paint


### PR DESCRIPTION

## About The Pull Request
Adds hand labelers and mod paint kits to loadouts.
## Why it's Good for the Game
These let you customize your belongings at roundstart more, which is fun.
## Proof of Testing
<details>
<summary>Screenshots/Videos</summary>
<img width="818" height="644" alt="image" src="https://github.com/user-attachments/assets/54addcd2-d99d-4bee-9a0a-8ca26ee52df6" />
<img width="935" height="230" alt="image" src="https://github.com/user-attachments/assets/44e63bc2-21c6-43fd-85a5-1e6d4eff7d0c" />
</details>

## Changelog
:cl:
add: Added hand labelers and MOD paint kits to loadouts.
/:cl:
