### PR TITLE
[NON-MODULAR] Stops you from detaching a vital head using Cybernetic Limb Mounts

### DIFF
--- a/modular_nova/modules/robot_limb_detach/code/robot_limb_detach_quirk.dm
+++ b/modular_nova/modules/robot_limb_detach/code/robot_limb_detach_quirk.dm
@@ -48,7 +48,9 @@
 
 	var/list/robot_parts = list()
 	for (var/obj/item/bodypart/possible_part as anything in cast_on.bodyparts)
-		if ((possible_part.bodytype & BODYTYPE_ROBOTIC) && !(possible_part.body_zone in exclusions)) //only robot limbs and only if they're not crucial to our like, ongoing life, you know?
+	//OCULIS EDIT START - Adds a check for !(possible_part.bodypart_flags & BODYPART_UNREMOVABLE) that for some reason did not exist before.
+		if ((possible_part.bodytype & BODYTYPE_ROBOTIC) && !(possible_part.bodypart_flags & BODYPART_UNREMOVABLE) && !(possible_part.body_zone in exclusions)) //only robot limbs and only if they're not crucial to our like, ongoing life, you know?
+	//OCULIS EDIT END
 			robot_parts += possible_part
 
 	if (!length(robot_parts))

--- a/modular_nova/modules/robot_limb_detach/code/robot_limb_detach_quirk.dm
+++ b/modular_nova/modules/robot_limb_detach/code/robot_limb_detach_quirk.dm
@@ -41,8 +41,10 @@
 
 	var/list/exclusions = list()
 	exclusions += BODY_ZONE_CHEST
-	if (!issynthetic(cast_on))
-		exclusions += BODY_ZONE_HEAD // no decapitating yourself unless you're a synthetic, who keep their brains in their chest
+	//OCULIS EDIT START - Synths, in fact, do NOT always have their brain in their chest. Stops people from accidentally pulling off their vital head.
+	if (locate(/obj/item/organ/brain) in cast_on.get_bodypart(BODY_ZONE_HEAD)) //ORIGINAL: if (!issynthetic(cast_on))
+		exclusions += BODY_ZONE_HEAD // no decapitating yourself unless your brain is not in your head.
+	//OCULIS EDIT END
 
 	var/list/robot_parts = list()
 	for (var/obj/item/bodypart/possible_part as anything in cast_on.bodyparts)


### PR DESCRIPTION

## About The Pull Request
The previous check for Cybernetic Limb Mounts regarding head being valid or invalid assumes all Synthetics have their brain in their chest, and everyone else does not. This is not always the case.
This PR thus adjusts the check to instead detect if there is a brain in the head, or not, which should be far more reliable.

While testing I also noticed that the quirk lets you pull off unremovable limbs (such as stumps which are never meant to be removed). This fixes that, too.
## Why it's Good for the Game
The previous intent of the implementation (preventing detachment of vitals) was not achieved by the previous code.
This resolves that.
Unremovable limbs probably shouldn't be removed, either!
## Proof of Testing
<details>
<summary>Screenshots/Videos</summary>
<img width="790" height="439" alt="image" src="https://github.com/user-attachments/assets/0a6813d7-f0ae-4e87-a5f0-1b27b7f832a7" />
<img width="757" height="459" alt="image" src="https://github.com/user-attachments/assets/20f639f8-fb59-46a9-bd1f-c2b1dd3d40db" />

</details>

## Changelog
:cl:
fix: The Cybernetic Limb Mounts trait is now better at deciding whether you should or shouldn't be able to pull off your own head (limb blacklisted if it contains your brain instead of only if you are organic).
fix: The Cybernetic Limb Mounts trait no longer lets you pull off limbs with the BODYPART_UNREMOVABLE flag.
/:cl:
