### PR TITLE
[NON-MODULAR] Fixes NIF repairs being impossible

### DIFF
--- a/modular_nova/modules/customization/modules/surgery/organs/nif.dm
+++ b/modular_nova/modules/customization/modules/surgery/organs/nif.dm
@@ -11,6 +11,7 @@
 	time = 12 SECONDS
 	all_surgery_states_required = SURGERY_SKIN_OPEN | SURGERY_BONE_SAWED | SURGERY_ORGANS_CUT
 	any_surgery_states_blocked = SURGERY_VESSELS_UNCLAMPED
+	required_organ_flag = ORGAN_ROBOTIC //OCULIS EDIT ADDITION - NIFs are always robotic organs. Thus, require a robotic organ.
 
 /datum/surgery_operation/organ/repair_nif/on_preop(obj/item/organ/cyberimp/brain/nif/installed_nif, mob/living/surgeon, obj/item/tool, list/operation_args)
 	display_results(


### PR DESCRIPTION

## About The Pull Request
NIFs currently cannot be repaired because the repair surgery expects an organic organ.. despite NIFs always being cyber organs.
This changes the required flags of the surgery to be correct.

Technically deserves to be upstream but I don't really feel like writing Nova PRs. Feel free to upstream.
## Why it's Good for the Game
Fix man good.
## Proof of Testing
<details>
<summary>Screenshots/Videos</summary>
<img width="907" height="510" alt="image" src="https://github.com/user-attachments/assets/583e4183-45b4-4910-a085-1f4d5db3b0a8" />

</details>

## Changelog
:cl:
fix: Surgical NIF repairs are no longer impossible.
/:cl:
