### PR TITLE
Removes the extra set of Jaws of Recovery on Void Raptor

### DIFF
--- a/_maps/map_files/VoidRaptor/VoidRaptor.dmm
+++ b/_maps/map_files/VoidRaptor/VoidRaptor.dmm
@@ -36195,7 +36195,6 @@
 	normaldoorcontrol = 1;
 	pixel_x = 5
 	},
-/obj/structure/fireaxecabinet/jawsofrecovery/directional/west,
 /turf/open/floor/iron/white,
 /area/station/medical/medbay/lobby)
 "knP" = (
@@ -37320,10 +37319,6 @@
 /obj/item/radio/headset/headset_med{
 	pixel_x = -4;
 	pixel_y = 14
-	},
-/obj/item/surgicaldrill{
-	pixel_x = -2;
-	pixel_y = 16
 	},
 /turf/open/floor/iron/white/smooth_edge{
 	dir = 4


### PR DESCRIPTION

## About The Pull Request

i added a set of jaws to Medbay a while back as a temporary fix for paramedics' suffering but i forgot to modularize it and then i added a modular paramedic dispatch recently which has a set of jaws so this PR fixes it
## Why it's Good for the Game

> fixes it
## Proof of Testing

yes i actually tested these because you can never be too careful (ignore me spending 4 hours straight typing up my first PR)
<details>
<summary>Screenshots/Videos</summary>
wow it's gone
<img width="357" height="411" alt="image" src="https://github.com/user-attachments/assets/f01e6378-b394-4f15-8a06-33dc1b7a6c3a" />

</details>

## Changelog
:cl:
map: Removed the extra set of Jaws of Recovery on Void Raptor
/:cl:
