### PR TITLE
[NON-MODULAR] Adjusts lung organ failure messages

### DIFF
--- a/code/modules/surgery/organs/internal/lungs/_lungs.dm
+++ b/code/modules/surgery/organs/internal/lungs/_lungs.dm
@@ -851,16 +851,15 @@
 		if(do_i_cough)
 			owner.emote("cough")
 	if(organ_flags & ORGAN_FAILING && !IS_UNCONSCIOUS_OR_CRIT(owner))
+		// owner.visible_message(span_danger("[owner] grabs [owner.p_their()] throat, struggling for breath!"), span_userdanger("You suddenly feel like you can't breathe!")) // OCULIS EDIT REMOVAL
 		//OCULIS EDIT ADDITION START - nobreath gives you a different failure message, additionally only guaranteed on the fail tick, 5% otherwise for nonvital, 10% if vital (to reduce spam).
 		var/is_nobreather = HAS_TRAIT(owner, TRAIT_NOBREATH)
 		if(!failed || SPT_PROB(is_nobreather ? 5 : 10, seconds_per_tick))
 			if(is_nobreather)
 				to_chat(owner, span_danger("[HAS_TRAIT(owner, TRAIT_SELF_AWARE) ? "Your lungs feel" : "Something within you feels"] wrong!")) //Self aware check for parity with examine.
 			else
+				owner.visible_message(span_danger("[owner] grabs [owner.p_their()] throat, struggling for breath!"), span_userdanger("You [failed ? "" : "suddenly "]feel like you can't breathe!"))
 		//OCULIS EDIT ADDITION END
-		//OCULIS EDIT START - indents visible message line twice to be contained by the added if-else, additionally "suddenly" is only present on the first tick.
-				owner.visible_message(span_danger("[owner] grabs [owner.p_their()] throat, struggling for breath!"), span_userdanger("You [failed ? "" : "suddenly "]feel like you can't breathe!")) //Original: owner.visible_message(span_danger("[owner] grabs [owner.p_their()] throat, struggling for breath!"), span_userdanger("You suddenly feel like you can't breathe!"))
-		//OCULIS EDIT END
 		failed = TRUE
 
 /obj/item/organ/lungs/get_availability(datum/species/owner_species, mob/living/owner_mob)

--- a/code/modules/surgery/organs/internal/lungs/_lungs.dm
+++ b/code/modules/surgery/organs/internal/lungs/_lungs.dm
@@ -851,7 +851,16 @@
 		if(do_i_cough)
 			owner.emote("cough")
 	if(organ_flags & ORGAN_FAILING && !IS_UNCONSCIOUS_OR_CRIT(owner))
-		owner.visible_message(span_danger("[owner] grabs [owner.p_their()] throat, struggling for breath!"), span_userdanger("You suddenly feel like you can't breathe!"))
+		//OCULIS EDIT ADDITION START - nobreath gives you a different failure message, additionally only guaranteed on the fail tick, 5% otherwise for nonvital, 10% if vital (to reduce spam).
+		var/is_nobreather = HAS_TRAIT(owner, TRAIT_NOBREATH)
+		if(!failed || SPT_PROB(is_nobreather ? 5 : 10, seconds_per_tick))
+			if(is_nobreather)
+				to_chat(owner, span_danger("[HAS_TRAIT(owner, TRAIT_SELF_AWARE) ? "Your lungs feel" : "Something within you feels"] wrong!")) //Self aware check for parity with examine.
+			else
+		//OCULIS EDIT ADDITION END
+		//OCULIS EDIT START - indents visible message line twice to be contained by the added if-else, additionally "suddenly" is only present on the first tick.
+				owner.visible_message(span_danger("[owner] grabs [owner.p_their()] throat, struggling for breath!"), span_userdanger("You [failed ? "" : "suddenly "]feel like you can't breathe!")) //Original: owner.visible_message(span_danger("[owner] grabs [owner.p_their()] throat, struggling for breath!"), span_userdanger("You suddenly feel like you can't breathe!"))
+		//OCULIS EDIT END
 		failed = TRUE
 
 /obj/item/organ/lungs/get_availability(datum/species/owner_species, mob/living/owner_mob)


### PR DESCRIPTION

## About The Pull Request
Currently, the messages you get for lung failure always act as if it is rendering you unable to respirate, even if you do not breathe.
They are also rather spammy, excessively so.

This PR makes the following adjustments:
- Nobreathers get a different message than those who choke, which informs them something is wrong within them, with less urgency. Due to them not breathing, it's also somewhat ambiguous about *what* is wrong unless self-aware (similar to self examine).
- The message itself fires less often. Instead of every organ tick, it is only guaranteed on the first tick post failure, being 10% / 5% per second afterwards (depending on whether you breathe, or not).
- One word in the standard message is adjusted as to not longer be a "sudden" feeling outside of the first tick.
## Why it's Good for the Game
Excessive large danger message spam is kind of bad.
This aims to strike a balance between reducing spam and still providing sufficient tells about what is going on (encouraging you to get organ failure checked out).
## Proof of Testing
<details>
<summary>Screenshots/Videos</summary>

[Needs to breathe]
<img width="480" height="181" alt="image" src="https://github.com/user-attachments/assets/c1e519f9-7807-4e9a-89f5-9c0c79b40189" />

[Nobreather]
<img width="472" height="85" alt="image" src="https://github.com/user-attachments/assets/e21e7b02-6e2d-4922-8972-5cd26946ca98" />

</details>

## Changelog
:cl:
qol: Lung organ failure messages are now different if you do not breathe.
qol: Lung organ failure messages no longer fire every organ tick, only being guaranteed on the first.
spellcheck: The feeling you get from lung failure if you need lungs to breathe is no longer "sudden" after the first tick.
/:cl:
