### PR TITLE
Small Void Raptor and Tramstation map tweaks

### DIFF
--- a/_maps/map_files/VoidRaptor/VoidRaptor.dmm
+++ b/_maps/map_files/VoidRaptor/VoidRaptor.dmm
@@ -15913,6 +15913,11 @@
 /obj/effect/turf_decal/trimline/dark_red/filled/line,
 /turf/open/floor/iron/dark,
 /area/station/security/execution/education)
+"eCe" = (
+/obj/structure/disposalpipe/segment,
+/obj/effect/turf_decal/trimline/purple/filled/line,
+/turf/open/floor/iron/white/smooth_large,
+/area/station/science/xenobiology)
 "eCj" = (
 /obj/effect/turf_decal/trimline/green/filled/warning{
 	dir = 5
@@ -23827,7 +23832,6 @@
 /turf/open/floor/iron/dark,
 /area/station/security/corrections_officer)
 "gPS" = (
-/obj/structure/window/spawner/directional/south,
 /obj/structure/table,
 /obj/machinery/xenoarch/researcher{
 	pixel_y = 5
@@ -50250,7 +50254,6 @@
 /turf/open/floor/circuit,
 /area/station/ai/satellite/interior)
 "ock" = (
-/obj/structure/window/spawner/directional/south,
 /obj/structure/table,
 /obj/item/disk/tech_disk{
 	pixel_x = -6
@@ -70826,6 +70829,11 @@
 /obj/structure/cable,
 /turf/open/floor/engine,
 /area/station/engineering/supermatter/room)
+"tAL" = (
+/obj/effect/spawner/structure/window/reinforced,
+/obj/structure/disposalpipe/segment,
+/turf/open/floor/plating,
+/area/station/science/xenobiology)
 "tAO" = (
 /obj/effect/turf_decal/trimline/purple/filled/warning{
 	dir = 8
@@ -76627,7 +76635,6 @@
 /turf/open/floor/iron/dark/smooth_large,
 /area/station/science/auxlab/firing_range)
 "viy" = (
-/obj/structure/window/spawner/directional/south,
 /obj/structure/table,
 /obj/machinery/cell_charger{
 	pixel_y = 3
@@ -105432,8 +105439,8 @@ wYK
 sMO
 nRo
 qNU
-qNU
-seE
+eCe
+tAL
 mTW
 odJ
 odJ

--- a/_maps/map_files/tramstation/tramstation.dmm
+++ b/_maps/map_files/tramstation/tramstation.dmm
@@ -57412,6 +57412,12 @@
 	amount = 15
 	},
 /obj/effect/turf_decal/tile/neutral/fourcorners,
+/obj/item/storage/belt/utility{
+	pixel_y = 2
+	},
+/obj/item/storage/belt/utility{
+	pixel_y = 6
+	},
 /turf/open/floor/iron/dark,
 /area/station/science/robotics/lab)
 "tcr" = (


### PR DESCRIPTION

## About The Pull Request
Void Raptor:
* Removes the windows between the machines and the tables in the science office.
* Fixes xenobio's disposals. (And added a missing trimline.)

Tramstation: 
* Adds 2 toolbelts to robotics.
## Why it's Good for the Game
The windows in void raptor science are just annoying and a timewaster for every round. Fixes are good. Tramstation should have some toolbelts in robotics to be up to par with other maps.
## Proof of Testing
It compiles.
## Changelog
:cl:
qol: Removed the windows between the machines and the tables in the Void Raptor science office.
fix: Fixed Void Raptor xenobio's disposals.
map: Added 2 toolbelts to Tramstation's robotics.
/:cl:
