### PR TITLE
Removes a reinforced wall inside of a reinforced window at Snowglobe's brig

### DIFF
--- a/_maps/map_files/Snowglobe/snowglobe.dmm
+++ b/_maps/map_files/Snowglobe/snowglobe.dmm
@@ -81375,11 +81375,6 @@
 /obj/item/hand_labeler,
 /turf/open/floor/iron/grimy,
 /area/station/commons/storage/art)
-"vKY" = (
-/obj/effect/spawner/structure/window/reinforced,
-/obj/structure/cable,
-/turf/closed/wall/r_wall,
-/area/station/security/execution/transfer)
 "vKZ" = (
 /obj/effect/turf_decal/siding/dark{
 	dir = 1
@@ -249348,7 +249343,7 @@ aoS
 pCR
 hOu
 wtV
-vKY
+rBm
 vMu
 vMu
 vMu


### PR DESCRIPTION

## About The Pull Request
Removes a reinforced wall inside of a reinforced window at Snowglobe's brig.
## Why it's Good for the Game
Map error fixed.
## Proof of Testing
Compiles.
## Changelog
:cl:
fix: Fixed Snowglobe's brig having a reinforced wall inside of a reinforced window.
/:cl:
