### PR TITLE
Adds In-Trial titles for heads of staff (and blueshield)

### DIFF
--- a/modular_nova/modules/alternative_job_titles/code/alt_job_titles.dm
+++ b/modular_nova/modules/alternative_job_titles/code/alt_job_titles.dm
@@ -100,6 +100,7 @@
 		"Command Bodyguard",
 		"Corporate Protection Specialist",
 		"Executive Protection Agent",
+		"Blueshield In-Trial", // OCULIS EDIT ADDITION
 	)
 
 /datum/job/botanist
@@ -144,6 +145,7 @@
 		"Site Director",
 		"Site Administrator",
 		"Station Commander",
+		"Captain In-Trial", // OCULIS EDIT ADDITION
 	)
 
 /datum/job/cargo_technician
@@ -201,6 +203,7 @@
 		"Engineering Foreman",
 		"Engineering Supervisor",
 		"Head of Engineering",
+		"Chief Engineer In-Trial", // OCULIS EDIT ADDITION
 	)
 
 /datum/job/chief_medical_officer
@@ -213,6 +216,7 @@
 		"Medical Director",
 		"Medical Administrator",
 		"Charge Nurse", // OCULIS EDIT ADDITION
+		"Chief Medical Officer In-Trial", // OCULIS EDIT ADDITION
 	)
 
 /datum/job/clown
@@ -339,6 +343,7 @@
 		"Executive Officer",
 		"First Officer", // OCULIS EDIT ADDITION
 		"Senior Sophont Resources Agent", // OCULIS EDIT ADDITION
+		"Head of Personnel In-Trial", // OCULIS EDIT ADDITION
 	)
 
 /datum/job/head_of_security
@@ -352,6 +357,7 @@
 		"Security Director",
 		"Sheriff",
 		"Marshall", // OCULIS EDIT ADDITION
+		"Head of Security In-Trial", // OCULIS EDIT ADDITION
 	)
 
 /datum/job/janitor
@@ -447,6 +453,7 @@
 		"Supply Foreman",
 		"Union Requisitions Officer",
 		"Warehouse Supervisor",
+		"Quartermaster In-Trial", // OCULIS EDIT ADDITION
 	)
 
 /datum/job/research_director
@@ -459,6 +466,7 @@
 		"Silicon Administrator",
 		"Research Administrator",
 		"Director of Science",
+		"Research Director In-Trial", // OCULIS EDIT ADDITION
 	)
 
 /datum/job/roboticist


### PR DESCRIPTION

## About The Pull Request
Adds In-Trial titles for heads of staff, and Blueshield. Such as "Chief Medical Officer In-Trial".
## Why it's Good for the Game
There's trainee titles for less senior roles, why not senior roles? There's also multiple characters that are trialing head of staff or interested in being a head of staff, and it would fit them well.
Also Tomas approved it.
<img width="556" height="233" alt="image" src="https://github.com/user-attachments/assets/7a905e46-7317-4c29-977f-88205a40cefa" />
## Proof of Testing
<details>
<summary>Screenshots/Videos</summary>
<img width="1150" height="975" alt="image" src="https://github.com/user-attachments/assets/34b1d8f7-2831-4699-bc1d-9633edae9d34" />
</details>

## Changelog
:cl:
add: Adds In-Trial titles for heads of staff, and Blueshield.
/:cl:
