### PR TITLE
Tweaks hallucination tiers, heavily modifies radio hallucinations

### DIFF
--- a/code/__DEFINES/text.dm
+++ b/code/__DEFINES/text.dm
@@ -109,7 +109,7 @@
 /// File location for eigenstasium lines
 #define EIGENSTASIUM_FILE "eigenstasium.json"
 /// File location for hallucination lines
-#define HALLUCINATION_FILE "hallucination.json"
+#define HALLUCINATION_FILE "oculis/hallucination.json" // OCULIS EDIT, ORIGINAL: #define HALLUCINATION_FILE "hallucination.json"
 /// File location for ninja lines
 #define NINJA_FILE "ninja.json"
 /// File loation for title splashes

--- a/code/modules/hallucination/battle.dm
+++ b/code/modules/hallucination/battle.dm
@@ -2,7 +2,7 @@
 /datum/hallucination/battle
 	abstract_hallucination_parent = /datum/hallucination/battle
 	random_hallucination_weight = 3
-	hallucination_tier = HALLUCINATION_TIER_COMMON
+	hallucination_tier = HALLUCINATION_TIER_UNCOMMON // OCULIS EDIT, ORIGINAL: hallucination_tier = HALLUCINATION_TIER_COMMON
 
 /datum/hallucination/battle/start()
 	if(HAS_TRAIT(hallucinator, TRAIT_DEAF))

--- a/code/modules/hallucination/blood_flow.dm
+++ b/code/modules/hallucination/blood_flow.dm
@@ -1,6 +1,6 @@
 /datum/hallucination/blood_flow
 	random_hallucination_weight = 3
-	hallucination_tier = HALLUCINATION_TIER_COMMON
+	hallucination_tier = HALLUCINATION_TIER_UNCOMMON // OCULIS EDIT, ORIGINAL: hallucination_tier = HALLUCINATION_TIER_COMMON
 	/// The bleeding hallucination's image
 	var/image/bleeding
 	/// Ref to the bleeding bodypart, necessary to unregister signals

--- a/code/modules/hallucination/body.dm
+++ b/code/modules/hallucination/body.dm
@@ -127,7 +127,7 @@
 /datum/hallucination/body/weird
 	random_hallucination_weight = 0.1 // These are very uncommon
 	abstract_hallucination_parent = /datum/hallucination/body/weird
-	hallucination_tier = HALLUCINATION_TIER_RARE
+	hallucination_tier = HALLUCINATION_TIER_UNCOMMON // OCULIS EDIT, ORIGINAL: hallucination_tier = HALLUCINATION_TIER_RARE
 
 /datum/hallucination/body/weird/alien
 	body_image_file = 'icons/mob/nonhuman-player/alien.dmi'

--- a/code/modules/hallucination/bolted_airlocks.dm
+++ b/code/modules/hallucination/bolted_airlocks.dm
@@ -1,6 +1,6 @@
 /datum/hallucination/bolts
 	random_hallucination_weight = 7
-	hallucination_tier = HALLUCINATION_TIER_COMMON
+	hallucination_tier = HALLUCINATION_TIER_UNCOMMON // OCULIS EDIT, ORIGINAL: hallucination_tier = HALLUCINATION_TIER_COMMON
 	/// A list of weakrefs to airlocks we bolt down around us
 	var/list/datum/weakref/airlocks_to_hit
 	/// A list of weakrefs to fake lock hallucinations we've created

--- a/code/modules/hallucination/delusions.dm
+++ b/code/modules/hallucination/delusions.dm
@@ -1,7 +1,7 @@
 /// A hallucination that makes us and (possibly) other people look like something else.
 /datum/hallucination/delusion
 	abstract_hallucination_parent = /datum/hallucination/delusion
-	hallucination_tier = HALLUCINATION_TIER_UNCOMMON
+	hallucination_tier = HALLUCINATION_TIER_VERYSPECIAL // OCULIS EDIT, ORIGINAL: hallucination_tier = HALLUCINATION_TIER_UNCOMMON
 
 	/// The duration of the delusions
 	var/duration = 30 SECONDS

--- a/code/modules/hallucination/fake_alert.dm
+++ b/code/modules/hallucination/fake_alert.dm
@@ -40,7 +40,7 @@
 	del_timer_id = QDEL_IN_STOPPABLE(src, duration)
 	return TRUE
 
-/* // OCULIS EDIT REMOVAL START
+/* // OCULIS EDIT REMOVAL START - these just barely work at all, given the variety of characters, what they breathe, and if they breathe at all
 /datum/hallucination/fake_alert/need_oxygen
 	alert_category = ALERT_NOT_ENOUGH_OXYGEN
 	alert_type = /atom/movable/screen/alert/not_enough_oxy

--- a/code/modules/hallucination/fake_alert.dm
+++ b/code/modules/hallucination/fake_alert.dm
@@ -2,7 +2,7 @@
 /datum/hallucination/fake_alert
 	abstract_hallucination_parent = /datum/hallucination/fake_alert
 	random_hallucination_weight = 1
-	hallucination_tier = HALLUCINATION_TIER_COMMON
+	hallucination_tier = HALLUCINATION_TIER_UNCOMMON // OCULIS EDIT, ORIGINAL: hallucination_tier = HALLUCINATION_TIER_COMMON
 
 	var/del_timer_id
 	/// The duration of the alert being thrown.
@@ -40,6 +40,7 @@
 	del_timer_id = QDEL_IN_STOPPABLE(src, duration)
 	return TRUE
 
+/* // OCULIS EDIT REMOVAL START
 /datum/hallucination/fake_alert/need_oxygen
 	alert_category = ALERT_NOT_ENOUGH_OXYGEN
 	alert_type = /atom/movable/screen/alert/not_enough_oxy
@@ -51,6 +52,7 @@
 /datum/hallucination/fake_alert/need_co2
 	alert_category = ALERT_NOT_ENOUGH_CO2
 	alert_type = /atom/movable/screen/alert/not_enough_co2
+*/ // OCULIS EDIT REMOVAL END
 
 /datum/hallucination/fake_alert/bad_oxygen
 	alert_category = ALERT_TOO_MUCH_OXYGEN
@@ -90,15 +92,19 @@
 /datum/hallucination/fake_alert/law
 	alert_category = ALERT_NEW_LAW
 	alert_type = /atom/movable/screen/alert/newlaw
+	hallucination_tier = HALLUCINATION_TIER_VERYSPECIAL // OCULIS EDIT ADDITION
 
 /datum/hallucination/fake_alert/locked
 	alert_category = ALERT_LOCKED
 	alert_type = /atom/movable/screen/alert/locked
+	hallucination_tier = HALLUCINATION_TIER_VERYSPECIAL // OCULIS EDIT ADDITION
 
 /datum/hallucination/fake_alert/hacked
 	alert_category = ALERT_HACKED
 	alert_type = /atom/movable/screen/alert/hacked
+	hallucination_tier = HALLUCINATION_TIER_VERYSPECIAL // OCULIS EDIT ADDITION
 
 /datum/hallucination/fake_alert/need_charge
 	alert_category = ALERT_CHARGE
 	alert_type = /atom/movable/screen/alert/emptycell
+	hallucination_tier = HALLUCINATION_TIER_VERYSPECIAL // OCULIS EDIT ADDITION

--- a/code/modules/hallucination/fake_chat.dm
+++ b/code/modules/hallucination/fake_chat.dm
@@ -117,7 +117,7 @@
 				"[hallucinator_name]?" = 1,
 				"[hallucinator_name], got a [pick("sec", "second", "moment", "minute")]?" = 1,
 				pick("[pick("What'd", "What did")] you need again, [hallucinator_name]?", "[hallucinator_name], [pick("what'd", "what did")] you need again?") = 1,
-				prob(50)?capitalize.pick_list_replacements(HALLUCINATION_FILE, "swears"):pick_list_replacements(HALLUCINATION_FILE, "swears") = 2,
+				prob(50)?uppertext(pick_list_replacements(HALLUCINATION_FILE, "swears")):pick_list_replacements(HALLUCINATION_FILE, "swears") = 2,
 			))
 			// OCULIS EDIT ADDITION END
 		else

--- a/code/modules/hallucination/fake_chat.dm
+++ b/code/modules/hallucination/fake_chat.dm
@@ -71,6 +71,20 @@
 	if(isnull(speaker))
 		return
 
+	// OCULIS EDIT ADDITION START
+	var/accused = pick(get_crewmember_minds())
+	var/accused_name = pick_weight(list(
+		first_name(accused.name) = 4
+		last_name(accused.name) = 2
+		accused.name = 1
+	))
+	var/hallucinator_name = pick_weight(list(
+		first_name(hallucinator.name) = 4
+		last_name(hallucinator.name) = 2
+		hallucinator.name = 1
+	))
+	// OCULIS EDIT ADDITION END
+
 	// Time to generate a message.
 	// Spans of our message
 	var/spans = list(speaker.speech_span)
@@ -80,6 +94,7 @@
 	// If we didn't have a preset one, let's make one up.
 	if(!chosen)
 		if(is_radio)
+			/* // OCULIS EDIT REMOVAL START
 			chosen = pick(list("Help!",
 				"Help [pick_list_replacements(HALLUCINATION_FILE, "location")][prob(50)?"!":"!!"]",
 				"[pick_list_replacements(HALLUCINATION_FILE, "people")] is [pick_list_replacements(HALLUCINATION_FILE, "accusations")]!",
@@ -90,10 +105,25 @@
 				"AI [pick("rogue", "is dead")]!!",
 				"Borgs rogue!",
 			))
+			*/ // OCULIS EDIT REMOVAL END
+			// OCULIS EDIT ADDITION START
+			chosen = pick(list(
+				pick("Help!", "Help!!", "Help me!!")
+				pick("Help, [pick_list_replacements(HALLUCINATION_FILE, "location")][prob(50)?"!":"!!"]", "[pick_list_replacements(HALLUCINATION_FILE, "location")], help[prob(50)?"!":"!!"]"),
+				"[accused_name] is [pick_list_replacements(HALLUCINATION_FILE, "accusations")][prob(50)?"!":"!!"]",
+				"[accused_name] has [pick_list_replacements(HALLUCINATION_FILE, "contraband")][prob(50)?"!":"!!"]",
+				"[pick_list_replacements(HALLUCINATION_FILE, "threat")] at [pick_list_replacements(HALLUCINATION_FILE, "location")][pick(".", "!", "!!")]",
+				"Where's [hallucinator_name]?",
+				"[hallucinator_name]?",
+				"[hallucinator_name], got a [pick("sec", "second", "moment", "minute")]?",
+				pick("[pick("What'd", "What did")] you need again, [hallucinator_name]?", "[hallucinator_name], [pick("what'd", "what did")] you need again?"),
+				prob(50)?capitalize.pick_list_replacements(HALLUCINATION_FILE, "swears"):pick_list_replacements(HALLUCINATION_FILE, "swears"),
+			))
+			// OCULIS EDIT ADDITION END
 		else
 			chosen = pick(list("[pick_list_replacements(HALLUCINATION_FILE, "suspicion")]",
 				"[pick_list_replacements(HALLUCINATION_FILE, "conversation")]",
-				"[pick_list_replacements(HALLUCINATION_FILE, "greetings")][first_name(hallucinator.name)]!",
+				"[pick_list_replacements(HALLUCINATION_FILE, "greetings")][hallucinator_name]!", // OCULIS EDIT, ORIGINAL: "[pick_list_replacements(HALLUCINATION_FILE, "greetings")][first_name(hallucinator.name)]!",
 				"[pick_list_replacements(HALLUCINATION_FILE, "getout")]",
 				"[pick_list_replacements(HALLUCINATION_FILE, "weird")]",
 				"[pick_list_replacements(HALLUCINATION_FILE, "didyouhearthat")]",
@@ -106,7 +136,7 @@
 
 		chosen = capitalize(chosen)
 
-	chosen = replacetext(chosen, "%TARGETNAME%", first_name(hallucinator.name))
+	chosen = replacetext(chosen, "%TARGETNAME%", hallucinator_name) // OCULIS EDIT, ORIGINAL: chosen = replacetext(chosen, "%TARGETNAME%", first_name(hallucinator.name))
 
 	// Log the message
 	feedback_details += "Type: [is_radio ? "Radio" : "Talk"], Source: [speaker.real_name], Message: [chosen]"

--- a/code/modules/hallucination/fake_chat.dm
+++ b/code/modules/hallucination/fake_chat.dm
@@ -107,17 +107,17 @@
 			))
 			*/ // OCULIS EDIT REMOVAL END
 			// OCULIS EDIT ADDITION START
-			chosen = pick(list(
-				pick("Help!", "Help!!", "Help me!!")
-				pick("Help, [pick_list_replacements(HALLUCINATION_FILE, "location")][prob(50)?"!":"!!"]", "[pick_list_replacements(HALLUCINATION_FILE, "location")], help[prob(50)?"!":"!!"]"),
-				"[accused_name] is [pick_list_replacements(HALLUCINATION_FILE, "accusations")][prob(50)?"!":"!!"]",
-				"[accused_name] has [pick_list_replacements(HALLUCINATION_FILE, "contraband")][prob(50)?"!":"!!"]",
-				"[pick_list_replacements(HALLUCINATION_FILE, "threat")] at [pick_list_replacements(HALLUCINATION_FILE, "location")][pick(".", "!", "!!")]",
-				"Where's [hallucinator_name]?",
-				"[hallucinator_name]?",
-				"[hallucinator_name], got a [pick("sec", "second", "moment", "minute")]?",
-				pick("[pick("What'd", "What did")] you need again, [hallucinator_name]?", "[hallucinator_name], [pick("what'd", "what did")] you need again?"),
-				prob(50)?capitalize.pick_list_replacements(HALLUCINATION_FILE, "swears"):pick_list_replacements(HALLUCINATION_FILE, "swears"),
+			chosen = pick_weight(list(
+				pick("Help!", "Help!!", "Help me!!") = 1,
+				pick("Help, [pick_list_replacements(HALLUCINATION_FILE, "location")][prob(50)?"!":"!!"]", "[pick_list_replacements(HALLUCINATION_FILE, "location")], help[prob(50)?"!":"!!"]") = 1,
+				"[accused_name] is [pick_list_replacements(HALLUCINATION_FILE, "accusations")][prob(50)?"!":"!!"]" = 1,
+				"[accused_name] has [pick_list_replacements(HALLUCINATION_FILE, "contraband")][prob(50)?"!":"!!"]" = 1,
+				"[pick_list_replacements(HALLUCINATION_FILE, "threat")] at [pick_list_replacements(HALLUCINATION_FILE, "location")][pick(".", "!", "!!")]" = 1,
+				"Where's [hallucinator_name]?" = 1,
+				"[hallucinator_name]?" = 1,
+				"[hallucinator_name], got a [pick("sec", "second", "moment", "minute")]?" = 1,
+				pick("[pick("What'd", "What did")] you need again, [hallucinator_name]?", "[hallucinator_name], [pick("what'd", "what did")] you need again?") = 1,
+				prob(50)?capitalize.pick_list_replacements(HALLUCINATION_FILE, "swears"):pick_list_replacements(HALLUCINATION_FILE, "swears") = 2,
 			))
 			// OCULIS EDIT ADDITION END
 		else

--- a/code/modules/hallucination/fake_chat.dm
+++ b/code/modules/hallucination/fake_chat.dm
@@ -74,14 +74,14 @@
 	// OCULIS EDIT ADDITION START
 	var/accused = pick(get_crewmember_minds())
 	var/accused_name = pick_weight(list(
-		first_name(accused.name) = 4
-		last_name(accused.name) = 2
-		accused.name = 1
+		first_name(accused.name) = 4,
+		last_name(accused.name) = 2,
+		accused.name = 1,
 	))
 	var/hallucinator_name = pick_weight(list(
-		first_name(hallucinator.name) = 4
-		last_name(hallucinator.name) = 2
-		hallucinator.name = 1
+		first_name(hallucinator.name) = 4,
+		last_name(hallucinator.name) = 2,
+		hallucinator.name = 1,
 	))
 	// OCULIS EDIT ADDITION END
 

--- a/code/modules/hallucination/fake_chat.dm
+++ b/code/modules/hallucination/fake_chat.dm
@@ -108,16 +108,17 @@
 			*/ // OCULIS EDIT REMOVAL END
 			// OCULIS EDIT ADDITION START
 			chosen = pick_weight(list(
-				pick("Help!", "Help!!", "Help me!!") = 1,
-				pick("Help, [pick_list_replacements(HALLUCINATION_FILE, "location")][prob(50)?"!":"!!"]", "[pick_list_replacements(HALLUCINATION_FILE, "location")], help[prob(50)?"!":"!!"]") = 1,
-				"[accused_name] is [pick_list_replacements(HALLUCINATION_FILE, "accusations")][prob(50)?"!":"!!"]" = 1,
-				"[accused_name] has [pick_list_replacements(HALLUCINATION_FILE, "contraband")][prob(50)?"!":"!!"]" = 1,
-				"[pick_list_replacements(HALLUCINATION_FILE, "threat")] at [pick_list_replacements(HALLUCINATION_FILE, "location")][pick(".", "!", "!!")]" = 1,
-				"Where's [hallucinator_name]?" = 1,
-				"[hallucinator_name]?" = 1,
-				"[hallucinator_name], got a [pick("sec", "second", "moment", "minute")]?" = 1,
-				pick("[pick("What'd", "What did")] you need again, [hallucinator_name]?", "[hallucinator_name], [pick("what'd", "what did")] you need again?") = 1,
-				prob(50)?uppertext(pick_list_replacements(HALLUCINATION_FILE, "swears")):pick_list_replacements(HALLUCINATION_FILE, "swears") = 2,
+				pick("Help!", "Help!!", "Help me!!") = 2,
+				pick("Help, [pick_list_replacements(HALLUCINATION_FILE, "location")][prob(50)?"!":"!!"]", "[pick_list_replacements(HALLUCINATION_FILE, "location")], help[prob(50)?"!":"!!"]") = 2,
+				"[accused_name] is [pick_list_replacements(HALLUCINATION_FILE, "accusations")][prob(50)?"!":"!!"]" = 2,
+				"[accused_name] has [pick_list_replacements(HALLUCINATION_FILE, "contraband")][prob(50)?"!":"!!"]" = 2,
+				"[pick_list_replacements(HALLUCINATION_FILE, "threat")] at [pick_list_replacements(HALLUCINATION_FILE, "location")][pick(".", "!", "!!")]" = 2,
+				"Where's [hallucinator_name]?" = 2,
+				"Arrest [hallucinator_name]!" = 1,
+				"[hallucinator_name]?" = 2,
+				"[hallucinator_name], got a [pick("sec", "second", "moment", "minute")]?" = 2,
+				pick("[pick("What'd", "What did")] you need again, [hallucinator_name]?", "[hallucinator_name], [pick("what'd", "what did")] you need again?") = 2,
+				prob(50)?uppertext(pick_list_replacements(HALLUCINATION_FILE, "swears")):pick_list_replacements(HALLUCINATION_FILE, "swears") = 4,
 			))
 			// OCULIS EDIT ADDITION END
 		else

--- a/code/modules/hallucination/fake_death.dm
+++ b/code/modules/hallucination/fake_death.dm
@@ -1,7 +1,7 @@
 // This hallucinations makes us suddenly think we died, stopping us / changing our hud / sending a fake deadchat message.
 /datum/hallucination/death
 	random_hallucination_weight = 1
-	hallucination_tier = HALLUCINATION_TIER_UNCOMMON
+	hallucination_tier = HALLUCINATION_TIER_VERYSPECIAL // OCULIS EDIT, ORIGINAL: hallucination_tier = HALLUCINATION_TIER_UNCOMMON
 	/// Determines whether we floor them or just immobilize them
 	var/floor_them = TRUE
 

--- a/code/modules/hallucination/fake_plasmaflood.dm
+++ b/code/modules/hallucination/fake_plasmaflood.dm
@@ -5,7 +5,7 @@
 /// Plasma starts flooding from the nearby vent
 /datum/hallucination/fake_flood
 	random_hallucination_weight = 7
-	hallucination_tier = HALLUCINATION_TIER_UNCOMMON
+	hallucination_tier = HALLUCINATION_TIER_RARE // OCULIS EDIT, ORIGINAL: hallucination_tier = HALLUCINATION_TIER_UNCOMMON
 
 	var/list/image/flood_images = list()
 	var/list/obj/effect/plasma_image_holder/flood_image_holders = list()

--- a/code/modules/hallucination/fake_sound.dm
+++ b/code/modules/hallucination/fake_sound.dm
@@ -54,6 +54,7 @@
 
 /datum/hallucination/fake_sound/normal/boom
 	sound_type = list('sound/effects/explosion/explosion1.ogg', 'sound/effects/explosion/explosion2.ogg')
+	hallucination_tier = HALLUCINATION_TIER_RARE // OCULIS EDIT ADDITION
 
 /datum/hallucination/fake_sound/normal/distant_boom
 	sound_type = 'sound/effects/explosion/explosionfar.ogg'
@@ -64,6 +65,7 @@
 /datum/hallucination/fake_sound/normal/alarm
 	volume = 70
 	sound_type = 'sound/announcer/alarm/nuke_alarm.ogg'
+	hallucination_tier = HALLUCINATION_TIER_RARE // OCULIS EDIT ADDITION
 
 /datum/hallucination/fake_sound/normal/beepsky
 	volume = 35
@@ -151,6 +153,7 @@
 	random_hallucination_weight = 2 // "it's revs"
 	volume = 90
 	sound_type = 'sound/items/weapons/flash.ogg'
+	hallucination_tier = HALLUCINATION_TIER_UNCOMMON // OCULIS EDIT ADDITION
 
 /datum/hallucination/fake_sound/normal/ringtone
 	volume = 50
@@ -208,12 +211,13 @@
 	sound_vary = FALSE
 	no_source = TRUE
 	sound_type = 'sound/music/antag/monkey.ogg'
+	hallucination_tier = HALLUCINATION_TIER_RARE // OCULIS EDIT ADDITION
 
 /datum/hallucination/fake_sound/weird/colossus
 	sound_type = 'sound/effects/magic/clockwork/invoke_general.ogg'
 
 /datum/hallucination/fake_sound/weird/creepy
-	hallucination_tier = HALLUCINATION_TIER_COMMON
+	hallucination_tier = HALLUCINATION_TIER_UNCOMMON // OCULIS EDIT, ORIGINAL: hallucination_tier = HALLUCINATION_TIER_COMMON
 
 /datum/hallucination/fake_sound/weird/creepy/New(mob/living/hallucinator)
 	. = ..()
@@ -229,7 +233,7 @@
 /datum/hallucination/fake_sound/weird/game_over
 	sound_vary = FALSE
 	sound_type = 'sound/machines/compiler/compiler-failure.ogg'
-	hallucination_tier = HALLUCINATION_TIER_RARE
+	hallucination_tier = HALLUCINATION_TIER_VERYSPECIAL // OCULIS EDIT, ORIGINAL: hallucination_tier = HALLUCINATION_TIER_RARE
 
 /datum/hallucination/fake_sound/weird/hallelujah
 	sound_vary = FALSE
@@ -244,7 +248,7 @@
 	sound_vary = FALSE
 	no_source = TRUE
 	sound_type = 'sound/runtime/hyperspace/hyperspace_begin.ogg'
-	hallucination_tier = HALLUCINATION_TIER_COMMON
+	hallucination_tier = HALLUCINATION_TIER_UNCOMMON // OCULIS EDIT, ORIGINAL: hallucination_tier = HALLUCINATION_TIER_COMMON
 
 /datum/hallucination/fake_sound/weird/laugher
 	hallucination_tier = HALLUCINATION_TIER_COMMON
@@ -258,7 +262,7 @@
 	volume = 15
 	sound_vary = FALSE
 	sound_type = 'sound/items/weapons/ring.ogg'
-	hallucination_tier = HALLUCINATION_TIER_RARE
+	hallucination_tier = HALLUCINATION_TIER_UNCOMMON // OCULIS EDIT, ORIGINAL: hallucination_tier = HALLUCINATION_TIER_RARE
 
 /datum/hallucination/fake_sound/weird/phone/play_fake_sound(turf/source, sound_to_play)
 	for(var/next_ring in 1 to 3)
@@ -317,9 +321,11 @@
 	no_source = TRUE
 	sound_vary = FALSE
 	sound_type = 'sound/effects/hallucinations/radio_static.ogg'
+	hallucination_tier = HALLUCINATION_TIER_RARE // OCULIS EDIT ADDITION
 
 /datum/hallucination/fake_sound/weird/ice_crack
 	random_hallucination_weight = 0
 	volume = 100
 	no_source = TRUE
 	sound_type = 'sound/effects/ice_shovel.ogg'
+	hallucination_tier = HALLUCINATION_TIER_RARE // OCULIS EDIT ADDITION

--- a/code/modules/hallucination/hazard.dm
+++ b/code/modules/hallucination/hazard.dm
@@ -24,9 +24,11 @@
 
 /datum/hallucination/hazard/lava
 	hazard_type = /obj/effect/client_image_holder/hallucination/danger/lava
+	hallucination_tier = HALLUCINATION_TIER_VERYSPECIAL // OCULIS EDIT ADDITION
 
 /datum/hallucination/hazard/chasm
 	hazard_type = /obj/effect/client_image_holder/hallucination/danger/chasm
+	hallucination_tier = HALLUCINATION_TIER_VERYSPECIAL // OCULIS EDIT ADDITION
 
 /datum/hallucination/hazard/anomaly
 	hazard_type = /obj/effect/client_image_holder/hallucination/danger/anomaly

--- a/code/modules/hallucination/hud_screw.dm
+++ b/code/modules/hallucination/hud_screw.dm
@@ -2,7 +2,7 @@
 /datum/hallucination/screwy_hud
 	abstract_hallucination_parent = /datum/hallucination/screwy_hud
 	random_hallucination_weight = 4
-	hallucination_tier = HALLUCINATION_TIER_COMMON
+	hallucination_tier = HALLUCINATION_TIER_UNCOMMON // OCULIS EDIT, ORIGINAL: hallucination_tier = HALLUCINATION_TIER_COMMON
 
 	/// The type of hud we give to the hallucinator
 	var/screwy_hud_type = SCREWYHUD_NONE

--- a/code/modules/hallucination/ice_cube.dm
+++ b/code/modules/hallucination/ice_cube.dm
@@ -1,7 +1,7 @@
 /// Causes the hallucinator to believe themselves frozen in ice. Man am I glad he's frozen in there etc etc
 /datum/hallucination/ice
 	random_hallucination_weight = 3
-	hallucination_tier = HALLUCINATION_TIER_COMMON
+	hallucination_tier = HALLUCINATION_TIER_RARE // OCULIS EDIT, ORIGINAL: hallucination_tier = HALLUCINATION_TIER_COMMON
 
 	/// What icon file to use for our hallucinator
 	var/ice_icon = 'icons/effects/freeze.dmi'

--- a/code/modules/hallucination/inhand_fake_item.dm
+++ b/code/modules/hallucination/inhand_fake_item.dm
@@ -2,7 +2,7 @@
 /datum/hallucination/fake_item
 	abstract_hallucination_parent = /datum/hallucination/fake_item
 	random_hallucination_weight = 1
-	hallucination_tier = HALLUCINATION_TIER_COMMON
+	hallucination_tier = HALLUCINATION_TIER_RARE // OCULIS EDIT, ORIGINAL: hallucination_tier = HALLUCINATION_TIER_COMMON
 
 	/// A flag of slots this fake item can appear in.
 	var/valid_slots = ITEM_SLOT_HANDS|ITEM_SLOT_BELT|ITEM_SLOT_LPOCKET|ITEM_SLOT_RPOCKET

--- a/code/modules/hallucination/nearby_fake_item.dm
+++ b/code/modules/hallucination/nearby_fake_item.dm
@@ -2,7 +2,7 @@
 /datum/hallucination/nearby_fake_item
 	abstract_hallucination_parent = /datum/hallucination/nearby_fake_item
 	random_hallucination_weight = 1
-	hallucination_tier = HALLUCINATION_TIER_COMMON
+	hallucination_tier = HALLUCINATION_TIER_UNCOMMON // OCULIS EDIT, ORIGINAL: hallucination_tier = HALLUCINATION_TIER_COMMON
 
 	/// The icon file to draw from for left hand icons
 	var/left_hand_file

--- a/code/modules/hallucination/on_fire.dm
+++ b/code/modules/hallucination/on_fire.dm
@@ -3,7 +3,7 @@
 
 /datum/hallucination/fire
 	random_hallucination_weight = 3
-	hallucination_tier = HALLUCINATION_TIER_UNCOMMON
+	hallucination_tier = HALLUCINATION_TIER_RARE // OCULIS EDIT, ORIGINAL: hallucination_tier = HALLUCINATION_TIER_UNCOMMON
 
 	/// Are we currently burning our mob?
 	var/active = TRUE

--- a/code/modules/hallucination/shock.dm
+++ b/code/modules/hallucination/shock.dm
@@ -1,7 +1,7 @@
 /// Causes a fake "zap" to the hallucinator.
 /datum/hallucination/shock
 	random_hallucination_weight = 1 // really low weight, as it also has a snowflake check to trigger when bumping airlocks
-	hallucination_tier = HALLUCINATION_TIER_COMMON
+	hallucination_tier = HALLUCINATION_TIER_UNCOMMON // OCULIS EDIT, ORIGINAL: hallucination_tier = HALLUCINATION_TIER_COMMON
 
 	var/electrocution_icon = 'icons/mob/human/human.dmi'
 	var/electrocution_icon_state = "electrocuted_base"

--- a/strings/oculis/hallucination.json
+++ b/strings/oculis/hallucination.json
@@ -1,0 +1,301 @@
+{
+	"suspicion": [
+		"@pick(add_name)I know what you're doing",
+		"@pick(add_name)I'm watching you...",
+		"@pick(add_name)what are you hiding?",
+		"I saw that",
+		"I'm watching you"
+	],
+
+	"conversation": [
+		"But...",
+		"Hmm",
+		"Hold on",
+		"I doubt it",
+		"Nah",
+		"No",
+		"Uh...",
+		"Weird",
+		"Why?",
+		"Yeah, I know",
+		"Yeah",
+		"Yes",
+		"Yup"
+	],
+
+	"greetings": ["", "Hello", "Hey, ", "Hi ", "Wait, ", "Heya, ", "What's up, "],
+
+	"getout": [
+		"@pick(add_name)fuck off",
+		"@pick(add_name)get out!",
+		"@pick(add_name)get out",
+		"@pick(add_name)go away",
+		"@pick(add_name)out!",
+		"OUT!"
+	],
+
+	"weird": [
+		"#@§*&£",
+		"EEEeeeeEEEE",
+		"H-hhhhh...",
+		"H**p m*",
+		"Kchck-Chkck? Kchchck!",
+		"Kchckchk...",
+		"khhhhh"
+	],
+
+	"didyouhearthat": [
+		"Did you hear that?",
+		"Did you see that?",
+		"What was that?",
+		"...did you see that too?",
+		"...did you hear that too?"
+	],
+
+	"add_name": ["", "%TARGETNAME% ", "%TARGETNAME%, "],
+
+	"doubt": [
+		"@pick(add_name)hold on",
+		"@pick(add_name)wait",
+		"Uh...",
+		"Wait, what?",
+		"What?",
+		"Why?"
+	],
+
+	"aggressive": [
+		"@pick(add_name)fuck off!",
+		"@pick(add_name)fuck you!",
+		"@pick(add_name)get out!",
+		"@pick(add_name)give me that!",
+		"@pick(add_name)i'm going to kill you!",
+		"@pick(add_name)stop!!",
+		"@pick(add_name)stop it!"
+	],
+
+	"help": [
+		"HELP HER",
+		"HELP HIM",
+		"HELP ME",
+		"HELP THEM",
+		"HELP US",
+		"SAVE YOURSELF",
+		"HELP",
+		"HELP",
+		"HELP",
+		"Help",
+		"Help"
+	],
+
+	"escape": [
+		"@pick(add_name)follow me!",
+		"@pick(add_name)follow me",
+		"@pick(add_name)look out!",
+		"@pick(add_name)RUN!!",
+		"It's here!",
+		"Oh shit!",
+		"They're coming!",
+		"They're behind me!"
+	],
+
+	"infection_advice": [
+		"@pick(add_name)be careful",
+		"@pick(add_name)don't get close",
+		"@pick(add_name)help me",
+		"@pick(add_name)kill me",
+		"@pick(add_name)stay away"
+	],
+
+	"people": [
+		"%TARGETNAME%",
+		"AI",
+		"Borg",
+		"Captain",
+		"Ce",
+		"Chef",
+		"Clown",
+		"Cmo",
+		"Geneticist",
+		"Hop",
+		"Hos",
+		"Janitor",
+		"Mime",
+		"Qm",
+		"Rd",
+		"Robo"
+	],
+
+	"accusations": [
+		"shapeshifting",
+		"a cultist",
+		"a heretic",
+		"subverted",
+		"attacking me",
+		"dead",
+		"drawing runes",
+		"flashing people",
+		"kidnapping me",
+		"killing people",
+		"shooting me",
+		"an operative"
+	],
+
+	"contraband": [
+		"a bomb",
+		"a gun",
+		"a sword",
+		"an energy sword",
+		"a makarov",
+		"a mech",
+		"a powersink",
+		"a red suit",
+		"a red modsuit",
+		"an elite modsuit",
+		"a revolver",
+		"a supermatter shard",
+		"an armblade",
+		"a weird glow",
+		"a green glow",
+		"cult robes on",
+		"geometerist robes on",
+		"died",
+		"a dual energy sword",
+		"a sickle",
+		"my backpack",
+		"my heirloom",
+		"my id",
+		"my stuff",
+		"the fire axe",
+		"the spare id",
+		"a hostage"
+	],
+
+	"threat": [
+		"%TARGETNAME%",
+		"Blob",
+		"Blue APC",
+		"Bomb",
+		"Carp",
+		"Shapeshifter",
+		"Cultist",
+		"Geometerist",
+		"Dragon",
+		"Fire",
+		"Heretic",
+		"Magic-user",
+		"Reality criminal",
+		"I hear flashing",
+		"I hear fighting",
+		"I hear shooting",
+		"I hear gunshots",
+		"I hear lasers",
+		"Kudzu",
+		"Operative",
+		"Plasmaleak",
+		"Plasma leak",
+		"Revenant",
+		"Rune",
+		"Runes",
+		"Spiders"
+	],
+
+	"location": [
+		"@pick(sublocation) maintenance",
+		"atmos",
+		"botany",
+		"captain's office",
+		"cargo",
+		"engineering",
+		"maintenance",
+		"medbay",
+		"morgue",
+		"science",
+		"the brig",
+		"security",
+		"space near @pick(sublocation)",
+		"the ai satellite",
+		"the armory",
+		"the bridge",
+		"the chapel",
+		"the kitchen",
+		"the library",
+		"tool storage",
+		"virology",
+		"xenobio"
+	],
+
+	"sublocation": [
+		"atmos",
+		"botany",
+		"captain's office",
+		"cargo",
+		"engineering",
+		"maintenance",
+		"medbay",
+		"morgue",
+		"science",
+		"the brig",
+		"security",
+		"the ai satellite",
+		"the armory",
+		"the bridge",
+		"the chapel",
+		"the kitchen",
+		"the library",
+		"tool storage",
+		"virology",
+		"xenobio"
+	],
+
+	"advice": [
+		"Good luck. You'll need it.",
+		"Hmm...not sure about that.",
+		"Just do it.",
+		"Kill that person. You know who.",
+		"Look out!",
+		"No. Stop what you're doing.",
+		"Something is coming.",
+		"Something is wrong.",
+		"That person wants to kill you.",
+		"They're coming for you.",
+		"They're out to get you.",
+		"This will end badly.",
+		"Trust that person.",
+		"Trust no-one.",
+		"Yes. You're doing the right thing.",
+		"You have my permission. Do it.",
+		"You should be wary of that person.",
+		"You should go somewhere else. Quickly."
+	],
+
+	"chemicals": [
+		"?????",
+		"Air",
+		"Awesome",
+		"Blood",
+		"Button",
+		"Death",
+		"Despair",
+		"Earth",
+		"Electronics",
+		"Energy",
+		"Fire",
+		"Guts",
+		"Happiness",
+		"Infinity",
+		"Life",
+		"Lightning",
+		"Magic",
+		"Mana",
+		"Ooze",
+		"Pain",
+		"Phlebotinium",
+		"Something",
+		"Space",
+		"Spiders",
+		"Surprise",
+		"Time"
+	],
+
+	"swears": ["fuck", "shit", "damn", "god damn it", "goddammit", "fucking hell"]
+}


### PR DESCRIPTION

## About The Pull Request
Tweaks the tiers of a lot of hallucinations, makes less believable and more disruptive hallucinations rarer or outright disabled for RDS, and makes more believable and less disruptive hallucinations more common.
Reworks radio chatter hallucinations, makes them hopefully more believable and within the flavor of Oculis.
Changes text hallucinations to weighted randomly choose your first, last, or full name.
## Why it's Good for the Game
Requested by Keygenpie. Better flavor, less unreasonable disruption.
## Proof of Testing
<details>
<summary>Screenshots/Videos</summary>

</details>

## Changelog
:cl:
qol: Tweaked the tiers of a lot of hallucinations; made less believable and more disruptive hallucinations rarer or outright disabled for RDS, and made more believable and less disruptive hallucinations more common.
qol: Reworks radio chatter hallucinations, makes them hopefully more believable and within the flavor of Oculis.
/:cl:
