### PR TITLE
Fixes Claustrophobia Triggering When Polymorphed

### DIFF
--- a/code/datums/components/fearful/sources/_sources.dm
+++ b/code/datums/components/fearful/sources/_sources.dm
@@ -97,6 +97,11 @@
 	if (isturf(owner.loc))
 		return 0
 
+// OCULIS EDIT ADDITION START: Don't trigger when polymorphed
+	if (owner.has_status_effect(/datum/status_effect/grouped/stasis, STASIS_SHAPECHANGE_EFFECT))
+		return 0
+// OCULIS EDIT ADDITION END
+
 	if (COOLDOWN_FINISHED(src, message_cd) && SPT_PROB(15, seconds_per_tick))
 		to_chat(owner, span_warning("You feel trapped! Must escape... can't breathe..."))
 		COOLDOWN_START(src, message_cd, TERROR_MESSAGE_CD)


### PR DESCRIPTION

## About The Pull Request
Fixes a niche interaction where claustrophobia would trigger when a character is polymorphed, as a result of being kept in nullspace. 
## Why it's Good for the Game
Extremely odd interaction that doesn't quite make sense. Why would being polymorphed trigger one's claustrophobia? You also don't get any feedback that you ARE experiencing claustrophobia until you start randomly vomiting (which you also have no feedback for) so I feel safe to say this is safely bug territory. I'm probably the only person who will ever notice this, but still.
## Proof of Testing

Spent five minutes in game polymorphed with no fear triggers. Spent ~10 seconds in a locker and got expected fear triggers. Not something I can particularly show off visually.
## Changelog
:cl:
fix: being polymorphed will no longer trigger claustrophobia in those who have it
/:cl:
