### PR TITLE
Fix PKHammer Displacing Immovable Mobs

### DIFF
--- a/modular_nova/modules/mining_crushers/code/miningweapons.dm
+++ b/modular_nova/modules/mining_crushers/code/miningweapons.dm
@@ -160,7 +160,7 @@
 	. = ..()
 	if(HAS_TRAIT(user, TRAIT_PACIFISM) || !HAS_TRAIT(src, TRAIT_WIELDED))
 		return
-	else if(!QDELETED(target) && !target.anchored)
+	else if(!QDELETED(target) && !target.anchored && !(target.move_resist == INFINITY)) // OCULIS EDIT: PKHammer can no longer displace tendrils - ORIGINAL: else if(!QDELETED(target) && !target.anchored)
 		var/whack_speed = (2)
 		target.throw_at(throw_target, 2, whack_speed, user, gentle = TRUE)
 


### PR DESCRIPTION

## About The Pull Request
PKHammer had a check for anchored entities, but not entities with a move_resist score of INFINITY. This fixes that. Oops!
## Why it's Good for the Game
As funny as it is to knock around tendrils with the PKHammer, this is clearly not intended behavior
## Proof of Testing
It Works :) 
## Changelog
:cl:
fix: proto-kinetic hammers will no longer knockback immovable entities such as tendrils
/:cl:
