### PR TITLE
Adds DS-2-specific comms, removes Interdyne knowing codespeak

### DIFF
--- a/modular_nova/master_files/code/modules/mob_spawn/ghost_roles/mining_roles.dm
+++ b/modular_nova/master_files/code/modules/mob_spawn/ghost_roles/mining_roles.dm
@@ -275,25 +275,6 @@
 /obj/item/radio/headset/interdyne/comms
 	keyslot = /obj/item/encryptionkey/headset_syndicate/interdyne
 
-// OCULIS EDIT ADDITION START
-/obj/item/radio/headset/ds2
-	name = "\improper DS-2 headset"
-	desc = "A bowman headset with a red S on the earpiece, and 'Cybersun Industries' written in small text on the top strap. Protects the ears from flashbangs."
-	icon_state = "syndie_headset"
-	inhand_icon_state = null
-	radio_talk_sound = 'modular_nova/modules/radiosound/sound/radio/syndie.ogg'
-	keyslot = new /obj/item/encryptionkey/headset_syndicate/interdyne
-
-/obj/item/radio/headset/ds2/Initialize(mapload)
-	. = ..()
-	AddComponent(/datum/component/wearertargeting/earprotection, list(ITEM_SLOT_EARS))
-
-/obj/item/radio/headset/ds2/command
-	name = "\improper DS-2 command headset"
-	desc = "A commander's bowman headset, to direct your operatives with. It has a red S on the earpiece, and 'Cybersun Industries' written in small text on the top strap."
-	command = TRUE
-// OCULIS EDIT ADDITION END
-
 // STRUCTURES
 
 /obj/structure/closet/crate/freezer/sansufentanyl

--- a/modular_nova/master_files/code/modules/mob_spawn/ghost_roles/mining_roles.dm
+++ b/modular_nova/master_files/code/modules/mob_spawn/ghost_roles/mining_roles.dm
@@ -105,9 +105,11 @@
 	quirks_enabled = TRUE
 	allow_custom_character = GHOSTROLE_TAKE_PREFS_APPEARANCE
 
+/* // OCULIS EDIT REMOVAL START
 /obj/effect/mob_spawn/ghost_role/human/interdyne_planetary_base/special(mob/living/spawned_mob, mob/mob_possessor, apply_prefs)
 	. = ..()
 	spawned_mob.grant_language(/datum/language/codespeak, source = LANGUAGE_SPAWNER)
+*/ // OCULIS EDIT REMOVAL END
 
 /obj/effect/mob_spawn/ghost_role/human/interdyne_planetary_base/ice
 	outfit = /datum/outfit/interdyne_planetary_base/ice
@@ -272,6 +274,25 @@
 
 /obj/item/radio/headset/interdyne/comms
 	keyslot = /obj/item/encryptionkey/headset_syndicate/interdyne
+
+// OCULIS EDIT ADDITION START
+/obj/item/radio/headset/ds2
+	name = "\improper DS-2 headset"
+	desc = "A bowman headset with a red S on the earpiece, and 'Cybersun Industries' written in small text on the top strap. Protects the ears from flashbangs."
+	icon_state = "syndie_headset"
+	inhand_icon_state = null
+	radio_talk_sound = 'modular_nova/modules/radiosound/sound/radio/syndie.ogg'
+	keyslot = new /obj/item/encryptionkey/headset_syndicate/interdyne
+
+/obj/item/radio/headset/ds2/Initialize(mapload)
+	. = ..()
+	AddComponent(/datum/component/wearertargeting/earprotection, list(ITEM_SLOT_EARS))
+
+/obj/item/radio/headset/ds2/command
+	name = "\improper DS-2 command headset"
+	desc = "A commander's bowman headset, to direct your operatives with. It has a red S on the earpiece, and 'Cybersun Industries' written in small text on the top strap."
+	command = TRUE
+// OCULIS EDIT ADDITION END
 
 // STRUCTURES
 

--- a/modular_nova/modules/mapping/code/lockers/des_two/command.dm
+++ b/modular_nova/modules/mapping/code/lockers/des_two/command.dm
@@ -26,7 +26,7 @@
 
 	new /obj/item/ammo_box/magazine/m9mm_aps(src)
 	new /obj/item/storage/bag/garment/station_admiral(src)
-	new /obj/item/radio/headset/interdyne/command(src)
+	new /obj/item/radio/headset/ds2/command(src) // OCULIS EDIT, ORIGINAL: new /obj/item/radio/headset/interdyne/command(src)
 	new /obj/item/card/id/departmental_budget/ds2(src)
 	new /obj/item/storage/lockbox/medal/nova/synd(src)
 
@@ -68,7 +68,7 @@
 	new /obj/item/storage/belt/security/full(src)
 	new /obj/item/watertank/pepperspray(src)
 	new /obj/item/storage/bag/garment/master_arms(src)
-	new /obj/item/radio/headset/interdyne(src)
+	new /obj/item/radio/headset/ds2/command(src) // OCULIS EDIT, ORIGINAL: new /obj/item/radio/headset/interdyne(src)
 
 /obj/structure/closet/secure_closet/des_two/maa_locker/populate_contents_immediate()
 	. = ..()
@@ -108,7 +108,7 @@
 	new /obj/item/encryptionkey/headset_syndicate/interdyne(src)
 	new /obj/item/language_manual/codespeak_manual/unlimited(src)
 	new /obj/item/storage/bag/garment/corprate_liaison(src)
-	new /obj/item/radio/headset/interdyne/command(src)
+	new /obj/item/radio/headset/ds2/command(src) // OCULIS EDIT, ORIGINAL: new /obj/item/radio/headset/interdyne/command(src)
 
 /obj/structure/closet/secure_closet/interdynefob/deckofficer_locker
 	icon_door = "qm"

--- a/modular_nova/modules/mapping/code/lockers/des_two/security.dm
+++ b/modular_nova/modules/mapping/code/lockers/des_two/security.dm
@@ -34,7 +34,7 @@
 
 	new /obj/item/storage/belt/security/full(src)
 	new /obj/item/storage/bag/garment/brig_officer(src)
-	new /obj/item/radio/headset/interdyne(src)
+	new /obj/item/radio/headset/ds2(src) // OCULIS EDIT, ORIGINAL: new /obj/item/radio/headset/interdyne(src)
 
 /obj/structure/closet/secure_closet/des_two/brig_officer_locker/populate_contents_immediate()
 	. = ..()

--- a/modular_nova/modules/mapping/code/mob_spawns.dm
+++ b/modular_nova/modules/mapping/code/mob_spawns.dm
@@ -317,7 +317,7 @@
 	name = "DS-2 Operative"
 	uniform = /obj/item/clothing/under/syndicate/nova/tactical
 	shoes = /obj/item/clothing/shoes/combat
-	ears = /obj/item/radio/headset/interdyne
+	ears = /obj/item/radio/headset/ds2 // OCULIS EDIT, ORIGINAL: ears = /obj/item/radio/headset/interdyne
 	back = /obj/item/storage/backpack
 	backpack_contents = list(
 		/obj/item/storage/box/survival/interdyne = 1,
@@ -413,7 +413,7 @@
 		)
 	r_pocket = /obj/item/flashlight/seclite
 	mask = /obj/item/clothing/mask/gas/syndicate
-	ears = /obj/item/radio/headset/interdyne
+	ears = /obj/item/radio/headset/ds2 // OCULIS EDIT, ORIGINAL: ears = /obj/item/radio/headset/interdyne
 
 /datum/outfit/ds2/syndicate/post_equip(mob/living/carbon/human/syndicate)
 	syndicate.add_faction(ROLE_DS2)
@@ -424,7 +424,7 @@
 	name = "DS-2 Command Operative"
 	uniform = /obj/item/clothing/under/syndicate/nova/tactical
 	shoes = /obj/item/clothing/shoes/combat
-	ears = /obj/item/radio/headset/interdyne/command
+	ears = /obj/item/radio/headset/ds2/command // OCULIS EDIT, ORIGINAL: ears = /obj/item/radio/headset/interdyne/command
 	back = /obj/item/storage/backpack
 	backpack_contents = list(
 		/obj/item/storage/box/survival/interdyne = 1,

--- a/modular_nova/modules/mapping/code/radio.dm
+++ b/modular_nova/modules/mapping/code/radio.dm
@@ -21,11 +21,3 @@
 	flags_1 = parent_type::flags_1 | NO_NEW_GAGS_PREVIEW_1
 	channels = list(RADIO_CHANNEL_TARKON = 1)
 	special_channels = RADIO_SPECIAL_CENTCOM
-
-// OCULIS EDIT ADDITION START
-/obj/item/encryptionkey/headset_syndicate/ds2
-	name = "ds-2 radio encryption key"
-	flags_1 = parent_type::flags_1 | NO_NEW_GAGS_PREVIEW_1
-	channels = list(RADIO_CHANNEL_CYBERSUN = 1, RADIO_CHANNEL_INTERDYNE = 2)
-	special_channels = RADIO_SPECIAL_CENTCOM
-// OCULIS EDIT ADDITION END

--- a/modular_nova/modules/mapping/code/radio.dm
+++ b/modular_nova/modules/mapping/code/radio.dm
@@ -21,3 +21,11 @@
 	flags_1 = parent_type::flags_1 | NO_NEW_GAGS_PREVIEW_1
 	channels = list(RADIO_CHANNEL_TARKON = 1)
 	special_channels = RADIO_SPECIAL_CENTCOM
+
+// OCULIS EDIT ADDITION START
+/obj/item/encryptionkey/headset_syndicate/ds2
+	name = "ds-2 radio encryption key"
+	flags_1 = parent_type::flags_1 | NO_NEW_GAGS_PREVIEW_1
+	channels = list(RADIO_CHANNEL_CYBERSUN = 1, RADIO_CHANNEL_INTERDYNE = 2)
+	special_channels = RADIO_SPECIAL_CENTCOM
+// OCULIS EDIT ADDITION END

--- a/modular_oculis/modules/radio/radio.dm
+++ b/modular_oculis/modules/radio/radio.dm
@@ -10,7 +10,7 @@
 	icon_state = "syndie_headset"
 	inhand_icon_state = null
 	radio_talk_sound = 'modular_nova/modules/radiosound/sound/radio/syndie.ogg'
-	keyslot = new /obj/item/encryptionkey/headset_syndicate/interdyne
+	keyslot = new /obj/item/encryptionkey/headset_syndicate/ds2
 
 /obj/item/radio/headset/ds2/Initialize(mapload)
 	. = ..()

--- a/modular_oculis/modules/radio/radio.dm
+++ b/modular_oculis/modules/radio/radio.dm
@@ -1,0 +1,22 @@
+/obj/item/encryptionkey/headset_syndicate/ds2
+	name = "ds-2 radio encryption key"
+	flags_1 = parent_type::flags_1 | NO_NEW_GAGS_PREVIEW_1
+	channels = list(RADIO_CHANNEL_CYBERSUN = 1, RADIO_CHANNEL_INTERDYNE = 1)
+	special_channels = RADIO_SPECIAL_CENTCOM
+
+/obj/item/radio/headset/ds2
+	name = "\improper DS-2 headset"
+	desc = "A bowman headset with a red S on the earpiece, and 'Cybersun Industries' written in small text on the top strap. Protects the ears from flashbangs."
+	icon_state = "syndie_headset"
+	inhand_icon_state = null
+	radio_talk_sound = 'modular_nova/modules/radiosound/sound/radio/syndie.ogg'
+	keyslot = new /obj/item/encryptionkey/headset_syndicate/interdyne
+
+/obj/item/radio/headset/ds2/Initialize(mapload)
+	. = ..()
+	AddComponent(/datum/component/wearertargeting/earprotection, list(ITEM_SLOT_EARS))
+
+/obj/item/radio/headset/ds2/command
+	name = "\improper DS-2 command headset"
+	desc = "A commander's bowman headset, to direct your operatives with. It has a red S on the earpiece, and 'Cybersun Industries' written in small text on the top strap."
+	command = TRUE

--- a/tgstation.dme
+++ b/tgstation.dme
@@ -10452,6 +10452,7 @@
 #include "modular_oculis\modules\quirks\code\no_mail.dm"
 #include "modular_oculis\modules\quirks\code\scarred_eye.dm"
 #include "modular_oculis\modules\quirks\code\stowaway.dm"
+#include "modular_oculis\modules\radio\radio.dm"
 #include "modular_oculis\modules\redaction\code\admin.dm"
 #include "modular_oculis\modules\redaction\code\checks.dm"
 #include "modular_oculis\modules\redaction\code\redaction_subsystem.dm"


### PR DESCRIPTION

## About The Pull Request
Adds DS-2-specific headsets and associated encryption keys, which give the Cybersun and Interdyne channels, with Cybersun as default.
Removes Interdyne knowing codespeak.
## Why it's Good for the Game
This makes Interdyne a little more neutral, like they're supposed to be, since DS-2 can now talk securely amongst themselves without Interdyne listening in. It didn't make sense that the DS-2 would only be able to talk on Interdyne's channel, and that Interdyne would know the Syndicate's secret language even though they're not part of the Syndicate.
## Proof of Testing
<details>
<summary>Screenshots/Videos</summary>
Language menu of an Interdyne Scientist:
<img width="875" height="625" alt="image" src="https://github.com/user-attachments/assets/e2b4a084-ed33-46a8-b46e-a376f921b92b" />

The DS-2 command headset, and it being used:
<img width="652" height="392" alt="image" src="https://github.com/user-attachments/assets/44ba8c07-80bb-4d1f-9d24-2afffd424645" />
</details>

## Changelog
:cl:
add: Added DS-2-specific headsets and associated encryption keys, that have access to the Cybersun and Interdyne channels.
del: Removed Interdyne knowing codespeak.
/:cl:
