### PR TITLE
Reverts the command bar starting on Say, changes it to start in Command mode

### DIFF
--- a/tgui/packages/tgui-panel/verbs/CommandBar.tsx
+++ b/tgui/packages/tgui-panel/verbs/CommandBar.tsx
@@ -184,7 +184,7 @@ export function CommandBar() {
   const [selectedVerb, setSelectedVerb] = useState<Verb | null>(null);
   const [filledArgs, setFilledArgs] = useState<string[]>([]);
   const [lastTypepathRequest, setLastTypepathRequest] = useState('');
-  const [mode, setMode] = useState<Mode>('Say');
+  const [mode, setMode] = useState<Mode>('Command'); {/* OCULIS EDIT, ORIGINAL: const [mode, setMode] = useState<Mode>('Say'); */}
   const inputRef = useRef<HTMLInputElement>(null);
   const historyRef = useRef<string[]>([]);
   const [historyIndex, setHistoryIndex] = useState(-1);


### PR DESCRIPTION

## About The Pull Request
Changes the Command bar back to starting in Command mode instead of Say.
## Why it's Good for the Game
It's the command bar, not the say bar. We have a hotkey for say, keeping it on say by default is cluttered and pointless.
Also, it was requested on the discord.
<img width="582" height="287" alt="image" src="https://github.com/user-attachments/assets/e3c6a038-e56d-44a1-a640-48a171d2573f" />
## Proof of Testing
<details>
<summary>Screenshots/Videos</summary>
<img width="2601" height="1424" alt="image" src="https://github.com/user-attachments/assets/51fac2d5-a9e8-4f37-8132-6c5ead23471f" />
</details>

## Changelog
:cl:
qol: Reverted the command bar starting on Say. It now starts in Command mode.
/:cl:
