### PR TITLE
Un-permit-locks the Mírotvůrce personal pacifier

### DIFF
--- a/modular_nova/master_files/code/modules/cargo/packs/companies/energy.dm
+++ b/modular_nova/master_files/code/modules/cargo/packs/companies/energy.dm
@@ -104,9 +104,9 @@
 /datum/supply_pack/companies/energy/hc_surplus/crank_taser
 	contains = list(/obj/item/gun/energy/taser/crank)
 	cost = CARGO_CRATE_VALUE * 2
-	// access = FALSE // OCULIS EDIT
-	// access_view = FALSE // OCULIS EDIT
-	// express_lock = FALSE // OCULIS EDIT
+	access = FALSE
+	access_view = FALSE
+	express_lock = FALSE
 	order_flags = ORDER_COMPANY
 
 /datum/supply_pack/companies/energy/hc_surplus/stun_gun //Not a gun but it's only fair to place similar items close to each other


### PR DESCRIPTION

## About The Pull Request
Un-permit-locks the Mírotvůrce personal pacifier. Now anyone can buy it.
## Why it's Good for the Game
Honestly, I thought I left it unlocked in the first place when I permit-locked guns in cargo. It's just a weaker side-grade to security's tazer but intended for the crew to use, the crew should be able to use it.
## Proof of Testing
<details>
<summary>Screenshots/Videos</summary>
<img width="1000" height="937" alt="Screenshot 2026-08-28 181157" src="https://github.com/user-attachments/assets/a8855d24-682e-4c7b-a220-3a7008d10e22" />
</details>

## Changelog
:cl:
balance: Un-permit-locked the Mírotvůrce personal pacifier.
/:cl:
